### PR TITLE
feat: add built-in themes with independent theme and palette axes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
         - G204
         - G304
         - G704
+        - G705
     tagliatelle:
       case:
         rules:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ claude-statusline themes
 | `prompt` | Render the status line (also the default when no command is given) |
 | `init` | Create default config at `~/.config/claude-statusline/config.toml` |
 | `test` | Render with your config and mock data (for config iteration) |
-| `themes` | Preview all built-in themes with mock data |
+| `themes` | Preview all built-in themes and palettes with mock data |
 
 Global flags: `--config / -c` to override config path, `--version`.
 
@@ -96,19 +96,33 @@ Modules support a `style` field that accepts several formats:
 
 - **Named:** `red`, `green`, `cyan`, `bold`, `dim`, `italic`
 - **Hex:** `fg:#ff5500`, `bg:#333333`
-- **256-color:** `208`
+- **256-color:** `208`, `fg:208`, `bg:238`
 - **Combined:** `fg:#aaa bg:#333 bold`
-- **Palette:** `palette:accent`
+- **Palette:** `palette:accent`, `fg:palette:seg_fg bg:palette:dir_bg`
 
-## Themes
+## Themes and palettes
 
-Four palettes are built in: `default`, `tokyo-night`, `gruvbox`, and `catppuccin`. Switch with a single line:
+**Themes** control the visual structure (separators, padding, icons). **Palettes** control the colors. Any theme works with any palette.
 
 ```toml
-palette = "tokyo-night"
+theme = "powerline"
+palette = "catppuccin"
 ```
 
-Preview all themes: `claude-statusline themes`
+Preview all combinations: `claude-statusline themes`
+
+### Built-in themes
+
+| Theme | Look | Needs Nerd Font |
+|-------|------|-----------------|
+| `default` | Flat with `\|` pipes | No |
+| `powerline` | Arrow segments with colored backgrounds | Yes |
+| `rounded` | Capsule/pill segments with gaps | Yes |
+| `minimal` | Clean spacing, no separators or icons | No |
+
+### Built-in palettes
+
+Four palettes are built in: `default`, `tokyo-night`, `gruvbox`, and `catppuccin`.
 
 You can also define your own palette:
 
@@ -123,86 +137,27 @@ cost_high = "red"
 ctx_ok = "green"
 ctx_warn = "yellow"
 ctx_high = "red"
+# Segment colors (used by powerline/rounded themes)
+seg_fg = "black"
+dir_bg = "blue"
+git_bg = "green"
+model_bg = "magenta"
+cost_bg = "238"
+ctx_bg = "236"
 ```
 
-## Powerline
+### Overriding theme defaults
 
-Opt into powerline-style separators. Requires a [Nerd Font](https://www.nerdfonts.com/).
-
-The format string uses styled text groups for segment transitions:
-
-- `` (start cap) with `fg:` matching the first segment background
-- `` (arrow) with `fg:prev_bg bg:next_bg` for transitions between segments
-- Each module's `style` must include a matching `bg:` color
-- Each module's `format` should include padding spaces
+Themes set the format string and module configs, but you can override any field:
 
 ```toml
-format = "[](fg:blue)$directory[](fg:blue bg:green)$git_branch[](fg:green bg:magenta)$model[](fg:magenta)"
+theme = "powerline"
+palette = "catppuccin"
 
-[directory]
-format = " {{.Dir}} "
-style = "fg:black bg:blue"
-
-[git_branch]
-disabled = false
-format = "  {{.Branch}} "
-style = "fg:black bg:green"
-
+# Override just one module
 [model]
 format = " {{.DisplayName}} "
-style = "fg:black bg:magenta bold"
-```
-
-### Catppuccin Mocha Powerline
-
-A complete powerline theme using [Catppuccin Mocha](https://catppuccin.com/) colors:
-
-```toml
-palette = "catppuccin-mocha"
-
-format = "[](fg:#89b4fa)$directory[](fg:#89b4fa bg:#a6e3a1)$git_branch[](fg:#a6e3a1 bg:#cba6f7)$model[](fg:#cba6f7 bg:#45475a)$cost[](fg:#45475a bg:#313244)$context[](fg:#313244)"
-
-[palettes.catppuccin-mocha]
-accent = "#89b4fa"
-cost_ok = "#a6e3a1"
-cost_warn = "#f9e2af"
-cost_high = "#f38ba8"
-ctx_ok = "#a6e3a1"
-ctx_warn = "#f9e2af"
-ctx_high = "#f38ba8"
-
-[directory]
-format = " {{.Dir}} "
-style = "fg:#1e1e2e bg:#89b4fa"
-
-[git_branch]
-disabled = false
-format = "  {{.Branch}}{{if .InWorktree}} {{end}} "
-style = "fg:#1e1e2e bg:#a6e3a1"
-
-[model]
-format = " {{.DisplayName}} "
-style = "fg:#1e1e2e bg:#cba6f7 bold"
-
-[cost]
-format = " ${{printf \"%.2f\" .TotalCostUSD}} "
-style = "fg:#a6e3a1 bg:#45475a"
-thresholds = [
-  { above = 1.0, style = "fg:#f9e2af bg:#45475a" },
-  { above = 5.0, style = "fg:#f38ba8 bg:#45475a" },
-]
-
-[context]
-format = " {{.Bar}} {{printf \"%.0f\" .UsedPct}}% "
-style = "fg:#a6e3a1 bg:#313244"
-bar_width = 5
-bar_fill = "█"
-bar_empty = "░"
-thresholds = [
-  { above = 50, style = "fg:#f9e2af bg:#313244" },
-  { above = 70, style = "fg:#fab387 bg:#313244" },
-  { above = 90, style = "fg:#f38ba8 bg:#313244" },
-]
+style = "fg:palette:seg_fg bg:palette:model_bg bold"
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Preview all presets: `claude-statusline themes`
 |--------|-------------|-----------|
 | `default` | Flat with `\|` pipes, standard colors | No |
 | `minimal` | Clean spacing, no separators | No |
-| `pastel-powerline` | Pastel powerline arrows (purple/pink/peach/blue) | Yes |
+| `pastel-powerline` | Pastel powerline arrows (pink/peach/blue/teal) | Yes |
 | `tokyo-night` | Dark blues rounded powerline with gradient | Yes |
 | `gruvbox-rainbow` | Earthy rainbow powerline | Yes |
 | `catppuccin` | Catppuccin Mocha powerline | Yes |
@@ -131,7 +131,7 @@ Modules support a `style` field that accepts several formats:
 - **Named:** `red`, `green`, `cyan`, `bold`, `dim`, `italic`
 - **Hex:** `fg:#ff5500`, `bg:#333333`
 - **256-color:** `208`, `fg:208`, `bg:238`
-- **Combined:** `fg:#aaa bg:#333 bold`
+- **Combined:** `fg:#aabbcc bg:#333333 bold`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ claude-statusline themes
 | `prompt` | Render the status line (also the default when no command is given) |
 | `init` | Create default config at `~/.config/claude-statusline/config.toml` |
 | `test` | Render with your config and mock data (for config iteration) |
-| `themes` | Preview all built-in themes and palettes with mock data |
+| `themes` | Preview all built-in presets with mock data |
 
 Global flags: `--config / -c` to override config path, `--version`.
 
@@ -65,6 +65,40 @@ Works with zero config. The default format is:
 
 ```toml
 format = "$directory | $git_branch | $model | $cost | $context"
+```
+
+## Presets
+
+Presets are self-contained visual styles inspired by [Starship presets](https://starship.rs/presets/). Each preset defines the layout, separators, colors, and module configuration.
+
+```toml
+preset = "catppuccin"
+```
+
+Preview all presets: `claude-statusline themes`
+
+### Built-in presets
+
+| Preset | Description | Nerd Font |
+|--------|-------------|-----------|
+| `default` | Flat with `\|` pipes, standard colors | No |
+| `minimal` | Clean spacing, no separators | No |
+| `pastel-powerline` | Pastel powerline arrows (purple/pink/peach/blue) | Yes |
+| `tokyo-night` | Dark blues rounded powerline with gradient | Yes |
+| `gruvbox-rainbow` | Earthy rainbow powerline | Yes |
+| `catppuccin` | Catppuccin Mocha powerline | Yes |
+
+### Overriding preset defaults
+
+Presets set the format string and module configs, but you can override any field:
+
+```toml
+preset = "catppuccin"
+
+# Override just one module
+[model]
+format = " {{.DisplayName}} "
+style = "fg:#11111b bg:#cba6f7 bold"
 ```
 
 ## Modules
@@ -98,67 +132,6 @@ Modules support a `style` field that accepts several formats:
 - **Hex:** `fg:#ff5500`, `bg:#333333`
 - **256-color:** `208`, `fg:208`, `bg:238`
 - **Combined:** `fg:#aaa bg:#333 bold`
-- **Palette:** `palette:accent`, `fg:palette:seg_fg bg:palette:dir_bg`
-
-## Themes and palettes
-
-**Themes** control the visual structure (separators, padding, icons). **Palettes** control the colors. Any theme works with any palette.
-
-```toml
-theme = "powerline"
-palette = "catppuccin"
-```
-
-Preview all combinations: `claude-statusline themes`
-
-### Built-in themes
-
-| Theme | Look | Needs Nerd Font |
-|-------|------|-----------------|
-| `default` | Flat with `\|` pipes | No |
-| `powerline` | Arrow segments with colored backgrounds | Yes |
-| `rounded` | Capsule/pill segments with gaps | Yes |
-| `minimal` | Clean spacing, no separators or icons | No |
-
-### Built-in palettes
-
-Four palettes are built in: `default`, `tokyo-night`, `gruvbox`, and `catppuccin`.
-
-You can also define your own palette:
-
-```toml
-palette = "my-theme"
-
-[palettes.my-theme]
-accent = "#ff5500"
-cost_ok = "green"
-cost_warn = "yellow"
-cost_high = "red"
-ctx_ok = "green"
-ctx_warn = "yellow"
-ctx_high = "red"
-# Segment colors (used by powerline/rounded themes)
-seg_fg = "black"
-dir_bg = "blue"
-git_bg = "green"
-model_bg = "magenta"
-cost_bg = "238"
-ctx_bg = "236"
-```
-
-### Overriding theme defaults
-
-Themes set the format string and module configs, but you can override any field:
-
-```toml
-theme = "powerline"
-palette = "catppuccin"
-
-# Override just one module
-[model]
-format = " {{.DisplayName}} "
-style = "fg:palette:seg_fg bg:palette:model_bg bold"
-```
 
 ## License
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -141,7 +141,7 @@ func testCommand() *ucli.Command {
 func themesCommand() *ucli.Command {
 	return &ucli.Command{
 		Name:  "themes",
-		Usage: "Preview all built-in themes with mock data",
+		Usage: "Preview all built-in themes and palettes with mock data",
 		Action: func(cmd *ucli.Context) error {
 			writer := cmd.App.Writer
 			data := mockInput()
@@ -159,33 +159,45 @@ func themesCommand() *ucli.Command {
 				return fmt.Errorf("rendering current: %w", err)
 			}
 
-			_, _ = fmt.Fprintf(writer, "current:\n%s\n\n", output)
+			_, _ = fmt.Fprintf(writer, "current:\n  %s\n\n", output)
 
-			// Show all built-in palettes with default config.
-			defaults := config.Default()
+			// Show theme × palette matrix.
+			paletteNames := paletteNamesSorted()
 
-			names := make([]string, 0, len(defaults.Palettes))
-			for name := range defaults.Palettes {
-				names = append(names, name)
-			}
+			for _, themeName := range config.ThemeNames() {
+				_, _ = fmt.Fprintf(writer, "--- %s ---\n", themeName)
 
-			sort.Strings(names)
+				for _, paletteName := range paletteNames {
+					cfg, _ := config.ApplyTheme(themeName)
+					cfg.Palette = paletteName
 
-			for _, name := range names {
-				cfg := config.Default()
-				cfg.Palette = name
+					output, err := render.Render(cfg, data)
+					if err != nil {
+						return fmt.Errorf("rendering %s/%s: %w", themeName, paletteName, err)
+					}
 
-				output, err := render.Render(cfg, data)
-				if err != nil {
-					return fmt.Errorf("rendering theme %s: %w", name, err)
+					_, _ = fmt.Fprintf(writer, "  %-12s %s\n", paletteName+":", output)
 				}
 
-				_, _ = fmt.Fprintf(writer, "%s:\n%s\n\n", name, output)
+				_, _ = fmt.Fprintln(writer)
 			}
 
 			return nil
 		},
 	}
+}
+
+func paletteNamesSorted() []string {
+	defaults := config.Default()
+
+	names := make([]string, 0, len(defaults.Palettes))
+	for name := range defaults.Palettes {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	return names
 }
 
 //nolint:mnd // mock data uses literal values by design

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 
 	"github.com/felipeelias/claude-statusline/internal/config"
 	"github.com/felipeelias/claude-statusline/internal/input"
@@ -141,7 +140,7 @@ func testCommand() *ucli.Command {
 func themesCommand() *ucli.Command {
 	return &ucli.Command{
 		Name:  "themes",
-		Usage: "Preview all built-in themes and palettes with mock data",
+		Usage: "Preview all built-in presets with mock data",
 		Action: func(cmd *ucli.Context) error {
 			writer := cmd.App.Writer
 			data := mockInput()
@@ -161,43 +160,20 @@ func themesCommand() *ucli.Command {
 
 			_, _ = fmt.Fprintf(writer, "current:\n  %s\n\n", output)
 
-			// Show theme × palette matrix.
-			paletteNames := paletteNamesSorted()
+			for _, name := range config.PresetNames() {
+				cfg, _ := config.ApplyPreset(name)
 
-			for _, themeName := range config.ThemeNames() {
-				_, _ = fmt.Fprintf(writer, "--- %s ---\n", themeName)
-
-				for _, paletteName := range paletteNames {
-					cfg, _ := config.ApplyTheme(themeName)
-					cfg.Palette = paletteName
-
-					output, err := render.Render(cfg, data)
-					if err != nil {
-						return fmt.Errorf("rendering %s/%s: %w", themeName, paletteName, err)
-					}
-
-					_, _ = fmt.Fprintf(writer, "  %-12s %s\n", paletteName+":", output)
+				output, err := render.Render(cfg, data)
+				if err != nil {
+					return fmt.Errorf("rendering %s: %w", name, err)
 				}
 
-				_, _ = fmt.Fprintln(writer)
+				_, _ = fmt.Fprintf(writer, "%-18s %s\n", name+":", output)
 			}
 
 			return nil
 		},
 	}
-}
-
-func paletteNamesSorted() []string {
-	defaults := config.Default()
-
-	names := make([]string, 0, len(defaults.Palettes))
-	for name := range defaults.Palettes {
-		names = append(names, name)
-	}
-
-	sort.Strings(names)
-
-	return names
 }
 
 //nolint:mnd // mock data uses literal values by design

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -66,7 +66,7 @@ func TestInitCommand(t *testing.T) {
 	content, err := os.ReadFile(configPath)
 	require.NoError(t, err)
 	assert.Contains(t, string(content), "format =")
-	assert.Contains(t, string(content), `palette = "default"`)
+	assert.Contains(t, string(content), `preset = "default"`)
 }
 
 func TestInitCommandAlreadyExists(t *testing.T) {
@@ -105,16 +105,12 @@ func TestThemesCommand(t *testing.T) {
 	result := stdout.String()
 	assert.Contains(t, result, "current:")
 
-	// Theme sections
-	assert.Contains(t, result, "--- default ---")
-	assert.Contains(t, result, "--- powerline ---")
-	assert.Contains(t, result, "--- rounded ---")
-	assert.Contains(t, result, "--- minimal ---")
-
-	// Palette names within each section
+	// Preset names
 	assert.Contains(t, result, "default:")
+	assert.Contains(t, result, "minimal:")
+	assert.Contains(t, result, "pastel-powerline:")
 	assert.Contains(t, result, "tokyo-night:")
-	assert.Contains(t, result, "gruvbox:")
+	assert.Contains(t, result, "gruvbox-rainbow:")
 	assert.Contains(t, result, "catppuccin:")
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -104,6 +104,14 @@ func TestThemesCommand(t *testing.T) {
 
 	result := stdout.String()
 	assert.Contains(t, result, "current:")
+
+	// Theme sections
+	assert.Contains(t, result, "--- default ---")
+	assert.Contains(t, result, "--- powerline ---")
+	assert.Contains(t, result, "--- rounded ---")
+	assert.Contains(t, result, "--- minimal ---")
+
+	// Palette names within each section
 	assert.Contains(t, result, "default:")
 	assert.Contains(t, result, "tokyo-night:")
 	assert.Contains(t, result, "gruvbox:")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 
 // Config holds the full statusline configuration.
 type Config struct {
+	Theme        string                       `toml:"theme"`
 	Format       string                       `toml:"format"`
 	Palette      string                       `toml:"palette"`
 	Palettes     map[string]map[string]string `toml:"palettes"`
@@ -97,48 +98,53 @@ const (
 // defaultPalettes returns all built-in palette definitions.
 func defaultPalettes() map[string]map[string]string {
 	return map[string]map[string]string{
-		"default": {
-			"accent":    "cyan",
-			"cost_ok":   "green",
-			"cost_warn": "yellow",
-			"cost_high": "red",
-			"ctx_ok":    "green",
-			"ctx_warn":  "yellow",
-			"ctx_high":  "red",
-		},
-		"tokyo-night": {
-			"accent":    "#769ff0",
-			"cost_ok":   "#73daca",
-			"cost_warn": "#e0af68",
-			"cost_high": "#f7768e",
-			"ctx_ok":    "#73daca",
-			"ctx_warn":  "#e0af68",
-			"ctx_high":  "#f7768e",
-		},
-		"gruvbox": {
-			"accent":    "#83a598",
-			"cost_ok":   "#b8bb26",
-			"cost_warn": "#fabd2f",
-			"cost_high": "#fb4934",
-			"ctx_ok":    "#b8bb26",
-			"ctx_warn":  "#fabd2f",
-			"ctx_high":  "#fb4934",
-		},
-		"catppuccin": {
-			"accent":    "#89b4fa",
-			"cost_ok":   "#a6e3a1",
-			"cost_warn": "#f9e2af",
-			"cost_high": "#f38ba8",
-			"ctx_ok":    "#a6e3a1",
-			"ctx_warn":  "#f9e2af",
-			"ctx_high":  "#f38ba8",
-		},
+		"default":     paletteDefault(),
+		"tokyo-night": paletteTokyoNight(),
+		"gruvbox":     paletteGruvbox(),
+		"catppuccin":  paletteCatppuccin(),
+	}
+}
+
+func paletteDefault() map[string]string {
+	return map[string]string{
+		"accent": "cyan", "cost_ok": "green", "cost_warn": "yellow", "cost_high": "red",
+		"ctx_ok": "green", "ctx_warn": "yellow", "ctx_high": "red",
+		"seg_fg": "black", "dir_bg": "blue", "git_bg": "green",
+		"model_bg": "magenta", "cost_bg": "238", "ctx_bg": "236",
+	}
+}
+
+func paletteTokyoNight() map[string]string {
+	return map[string]string{
+		"accent": "#769ff0", "cost_ok": "#73daca", "cost_warn": "#e0af68", "cost_high": "#f7768e",
+		"ctx_ok": "#73daca", "ctx_warn": "#e0af68", "ctx_high": "#f7768e",
+		"seg_fg": "#1a1b26", "dir_bg": "#769ff0", "git_bg": "#73daca",
+		"model_bg": "#bb9af7", "cost_bg": "#414868", "ctx_bg": "#24283b",
+	}
+}
+
+func paletteGruvbox() map[string]string {
+	return map[string]string{
+		"accent": "#83a598", "cost_ok": "#b8bb26", "cost_warn": "#fabd2f", "cost_high": "#fb4934",
+		"ctx_ok": "#b8bb26", "ctx_warn": "#fabd2f", "ctx_high": "#fb4934",
+		"seg_fg": "#282828", "dir_bg": "#83a598", "git_bg": "#b8bb26",
+		"model_bg": "#d3869b", "cost_bg": "#504945", "ctx_bg": "#3c3836",
+	}
+}
+
+func paletteCatppuccin() map[string]string {
+	return map[string]string{
+		"accent": "#89b4fa", "cost_ok": "#a6e3a1", "cost_warn": "#f9e2af", "cost_high": "#f38ba8",
+		"ctx_ok": "#a6e3a1", "ctx_warn": "#f9e2af", "ctx_high": "#f38ba8",
+		"seg_fg": "#1e1e2e", "dir_bg": "#89b4fa", "git_bg": "#a6e3a1",
+		"model_bg": "#cba6f7", "cost_bg": "#45475a", "ctx_bg": "#313244",
 	}
 }
 
 // Default returns a Config with hardcoded default values.
 func Default() Config {
 	return Config{
+		Theme:    "default",
 		Format:   "$directory | $git_branch | $model | $cost | $context",
 		Palette:  "default",
 		Palettes: defaultPalettes(),
@@ -189,19 +195,37 @@ func Default() Config {
 	}
 }
 
+// themeHeader is used to extract the theme field from a TOML file
+// before applying the full config on top.
+type themeHeader struct {
+	Theme string `toml:"theme"`
+}
+
 // Load reads a TOML config file and merges it with defaults.
 // If the file does not exist, Default() is returned with no error.
 // If the file exists but has parse errors, an error is returned.
+//
+// Loading is two-pass: first the theme field is read to select the base
+// config, then the full file is decoded on top so user overrides layer cleanly.
 func Load(path string) (Config, error) {
-	cfg := Default()
-
 	_, err := os.Stat(path)
 	if errors.Is(err, os.ErrNotExist) {
-		return cfg, nil
+		return Default(), nil
 	}
 	if err != nil {
 		return Config{}, err
 	}
+
+	// Pass 1: read theme field.
+	var header themeHeader
+
+	_, err = toml.DecodeFile(path, &header)
+	if err != nil {
+		return Config{}, err
+	}
+
+	// Pass 2: start from themed base, decode user overrides on top.
+	cfg, _ := ApplyTheme(header.Theme)
 
 	_, err = toml.DecodeFile(path, &cfg)
 	if err != nil {
@@ -225,15 +249,22 @@ func DefaultPath() string {
 const sampleConfigTemplate = `# claude-statusline configuration
 # Docs: https://github.com/felipeelias/claude-statusline
 
+# Theme controls the visual structure (separators, padding, icons).
+# Built-in themes: "default", "powerline", "rounded", "minimal"
+# Note: "powerline" and "rounded" require a Nerd Font.
+theme = "default"
+
 # Format string controls the layout. Modules are referenced with $name.
 # Styled text groups use [text](style) syntax.
+# When using a theme, you typically don't need to change the format.
 format = "$directory | $git_branch | $model | $cost | $context"
 
 # Built-in palettes: "default", "tokyo-night", "gruvbox", "catppuccin"
-# Run 'claude-statusline themes' to preview all palettes.
+# Run 'claude-statusline themes' to preview all themes and palettes.
 palette = "default"
 
 # Custom palette: override or add your own palette colors.
+# Segment keys (seg_fg, dir_bg, etc.) are used by powerline/rounded themes.
 # [palettes.my-theme]
 # accent = "#ff5500"
 # cost_ok = "green"
@@ -242,6 +273,12 @@ palette = "default"
 # ctx_ok = "green"
 # ctx_warn = "yellow"
 # ctx_high = "red"
+# seg_fg = "black"
+# dir_bg = "blue"
+# git_bg = "green"
+# model_bg = "magenta"
+# cost_bg = "238"
+# ctx_bg = "236"
 
 # Module configuration. Each module supports format, style, and disabled.
 # Styles: "bold", "dim", "italic", "fg:#hex", "bg:#hex", "palette:name"
@@ -264,7 +301,7 @@ palette = "default"
 # ]
 
 # [context]
-# format = '{{.Bar}} {{printf "%.0f" .UsedPct}}%%'
+# format = '{{.Bar}} {{printf "%.0f" .UsedPct}}%'
 # style = "palette:ctx_ok"
 # bar_width = 5
 # bar_fill = "█"
@@ -298,12 +335,11 @@ func SampleConfig() string {
 }
 
 // ResolveStyle resolves palette references in a style string.
-// If styleStr starts with "palette:", the key after the prefix is looked up in
-// the active palette. If found, the palette value is returned.
-// Otherwise styleStr is returned unchanged.
+// It handles both bare "palette:key" tokens and compound styles like
+// "fg:palette:key bg:palette:key bold". Each space-separated token is
+// checked for palette references and resolved independently.
 func (c Config) ResolveStyle(styleStr string) string {
-	key, found := strings.CutPrefix(styleStr, "palette:")
-	if !found {
+	if !strings.Contains(styleStr, "palette:") {
 		return styleStr
 	}
 
@@ -312,10 +348,37 @@ func (c Config) ResolveStyle(styleStr string) string {
 		return styleStr
 	}
 
-	value, valueExists := palette[key]
-	if !valueExists {
-		return styleStr
+	var result []string
+
+	for token := range strings.FieldsSeq(styleStr) {
+		result = append(result, resolveToken(token, palette))
 	}
 
-	return value
+	return strings.Join(result, " ")
+}
+
+// resolveToken resolves a single token against a palette.
+// Handles: "palette:key", "fg:palette:key", "bg:palette:key".
+func resolveToken(token string, palette map[string]string) string {
+	if key, found := strings.CutPrefix(token, "palette:"); found {
+		if value, ok := palette[key]; ok {
+			return value
+		}
+
+		return token
+	}
+
+	for _, prefix := range []string{"fg:", "bg:"} {
+		if rest, found := strings.CutPrefix(token, prefix); found {
+			if key, hasPalette := strings.CutPrefix(rest, "palette:"); hasPalette {
+				if value, ok := palette[key]; ok {
+					return prefix + value
+				}
+
+				return token
+			}
+		}
+	}
+
+	return token
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,24 +4,21 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/BurntSushi/toml"
 )
 
 // Config holds the full statusline configuration.
 type Config struct {
-	Theme        string                       `toml:"theme"`
-	Format       string                       `toml:"format"`
-	Palette      string                       `toml:"palette"`
-	Palettes     map[string]map[string]string `toml:"palettes"`
-	Model        ModelConfig                  `toml:"model"`
-	Directory    DirectoryConfig              `toml:"directory"`
-	Cost         CostConfig                   `toml:"cost"`
-	Context      ContextConfig                `toml:"context"`
-	GitBranch    GitBranchConfig              `toml:"git_branch"`
-	SessionTimer SessionTimerConfig           `toml:"session_timer"`
-	LinesChanged LinesChangedConfig           `toml:"lines_changed"`
+	Preset       string             `toml:"preset"`
+	Format       string             `toml:"format"`
+	Model        ModelConfig        `toml:"model"`
+	Directory    DirectoryConfig    `toml:"directory"`
+	Cost         CostConfig         `toml:"cost"`
+	Context      ContextConfig      `toml:"context"`
+	GitBranch    GitBranchConfig    `toml:"git_branch"`
+	SessionTimer SessionTimerConfig `toml:"session_timer"`
+	LinesChanged LinesChangedConfig `toml:"lines_changed"`
 }
 
 // Threshold defines a conditional style based on a numeric value.
@@ -91,95 +88,45 @@ const (
 	defaultBarWidth         = 5
 	costWarnThreshold       = 5.0
 	ctxWarnThreshold        = 50
-	ctxMedThreshold         = 70
 	ctxHighThreshold        = 90
 )
-
-// defaultPalettes returns all built-in palette definitions.
-func defaultPalettes() map[string]map[string]string {
-	return map[string]map[string]string{
-		"default":     paletteDefault(),
-		"tokyo-night": paletteTokyoNight(),
-		"gruvbox":     paletteGruvbox(),
-		"catppuccin":  paletteCatppuccin(),
-	}
-}
-
-func paletteDefault() map[string]string {
-	return map[string]string{
-		"accent": "cyan", "cost_ok": "green", "cost_warn": "yellow", "cost_high": "red",
-		"ctx_ok": "green", "ctx_warn": "yellow", "ctx_high": "red",
-		"seg_fg": "black", "dir_bg": "blue", "git_bg": "green",
-		"model_bg": "magenta", "cost_bg": "238", "ctx_bg": "236",
-	}
-}
-
-func paletteTokyoNight() map[string]string {
-	return map[string]string{
-		"accent": "#769ff0", "cost_ok": "#73daca", "cost_warn": "#e0af68", "cost_high": "#f7768e",
-		"ctx_ok": "#73daca", "ctx_warn": "#e0af68", "ctx_high": "#f7768e",
-		"seg_fg": "#1a1b26", "dir_bg": "#769ff0", "git_bg": "#73daca",
-		"model_bg": "#bb9af7", "cost_bg": "#414868", "ctx_bg": "#24283b",
-	}
-}
-
-func paletteGruvbox() map[string]string {
-	return map[string]string{
-		"accent": "#83a598", "cost_ok": "#b8bb26", "cost_warn": "#fabd2f", "cost_high": "#fb4934",
-		"ctx_ok": "#b8bb26", "ctx_warn": "#fabd2f", "ctx_high": "#fb4934",
-		"seg_fg": "#282828", "dir_bg": "#83a598", "git_bg": "#b8bb26",
-		"model_bg": "#d3869b", "cost_bg": "#504945", "ctx_bg": "#3c3836",
-	}
-}
-
-func paletteCatppuccin() map[string]string {
-	return map[string]string{
-		"accent": "#89b4fa", "cost_ok": "#a6e3a1", "cost_warn": "#f9e2af", "cost_high": "#f38ba8",
-		"ctx_ok": "#a6e3a1", "ctx_warn": "#f9e2af", "ctx_high": "#f38ba8",
-		"seg_fg": "#1e1e2e", "dir_bg": "#89b4fa", "git_bg": "#a6e3a1",
-		"model_bg": "#cba6f7", "cost_bg": "#45475a", "ctx_bg": "#313244",
-	}
-}
 
 // Default returns a Config with hardcoded default values.
 func Default() Config {
 	return Config{
-		Theme:    "default",
-		Format:   "$directory | $git_branch | $model | $cost | $context",
-		Palette:  "default",
-		Palettes: defaultPalettes(),
+		Preset: "default",
+		Format: "$directory | $git_branch | $model | $cost | $context",
 		Model: ModelConfig{
 			Format: "{{.DisplayName}}",
 			Style:  "bold",
 		},
 		Directory: DirectoryConfig{
 			Format:           "{{.Dir}}",
-			Style:            "palette:accent",
+			Style:            "cyan",
 			TruncationLength: defaultTruncationLength,
 		},
 		Cost: CostConfig{
 			Format: `${{printf "%.2f" .TotalCostUSD}}`,
-			Style:  "palette:cost_ok",
+			Style:  "green",
 			Thresholds: []Threshold{
-				{Above: 1.0, Style: "palette:cost_warn"},
-				{Above: costWarnThreshold, Style: "palette:cost_high"},
+				{Above: 1.0, Style: "yellow"},
+				{Above: costWarnThreshold, Style: "red"},
 			},
 		},
 		Context: ContextConfig{
 			Format:   `{{.Bar}} {{printf "%.0f" .UsedPct}}%`,
-			Style:    "palette:ctx_ok",
+			Style:    "green",
 			BarWidth: defaultBarWidth,
 			BarFill:  "\u2588",
 			BarEmpty: "\u2591",
 			Thresholds: []Threshold{
-				{Above: ctxWarnThreshold, Style: "palette:ctx_warn"},
-				{Above: ctxMedThreshold, Style: "208"},
-				{Above: ctxHighThreshold, Style: "palette:ctx_high"},
+				{Above: ctxWarnThreshold, Style: "yellow"},
+				{Above: ctxHighThreshold, Style: "red"},
 			},
 		},
 		GitBranch: GitBranchConfig{
 			Format: "\ue0a0 {{.Branch}}{{if .InWorktree}} \uf0e8{{end}}",
-			Style:  "palette:accent",
+			Style:  "cyan",
 		},
 		SessionTimer: SessionTimerConfig{
 			Format:   "{{.Elapsed}}",
@@ -195,17 +142,17 @@ func Default() Config {
 	}
 }
 
-// themeHeader is used to extract the theme field from a TOML file
+// presetHeader is used to extract the preset field from a TOML file
 // before applying the full config on top.
-type themeHeader struct {
-	Theme string `toml:"theme"`
+type presetHeader struct {
+	Preset string `toml:"preset"`
 }
 
 // Load reads a TOML config file and merges it with defaults.
 // If the file does not exist, Default() is returned with no error.
 // If the file exists but has parse errors, an error is returned.
 //
-// Loading is two-pass: first the theme field is read to select the base
+// Loading is two-pass: first the preset field is read to select the base
 // config, then the full file is decoded on top so user overrides layer cleanly.
 func Load(path string) (Config, error) {
 	_, err := os.Stat(path)
@@ -216,16 +163,16 @@ func Load(path string) (Config, error) {
 		return Config{}, err
 	}
 
-	// Pass 1: read theme field.
-	var header themeHeader
+	// Pass 1: read preset field.
+	var header presetHeader
 
 	_, err = toml.DecodeFile(path, &header)
 	if err != nil {
 		return Config{}, err
 	}
 
-	// Pass 2: start from themed base, decode user overrides on top.
-	cfg, _ := ApplyTheme(header.Theme)
+	// Pass 2: start from preset base, decode user overrides on top.
+	cfg, _ := ApplyPreset(header.Preset)
 
 	_, err = toml.DecodeFile(path, &cfg)
 	if err != nil {
@@ -249,39 +196,24 @@ func DefaultPath() string {
 const sampleConfigTemplate = `# claude-statusline configuration
 # Docs: https://github.com/felipeelias/claude-statusline
 
-# Theme controls the visual structure (separators, padding, icons).
-# Built-in themes: "default", "powerline", "rounded", "minimal"
-# Note: "powerline" and "rounded" require a Nerd Font.
-theme = "default"
+# Preset defines the complete visual style (layout, colors, separators).
+# Built-in presets:
+#   "default"          - flat with | pipes (no Nerd Font needed)
+#   "minimal"          - clean spacing, no separators (no Nerd Font needed)
+#   "pastel-powerline" - pastel powerline arrows (Nerd Font)
+#   "tokyo-night"      - dark blues rounded powerline (Nerd Font)
+#   "gruvbox-rainbow"  - earthy rainbow powerline (Nerd Font)
+#   "catppuccin"       - Catppuccin Mocha powerline (Nerd Font)
+# Run 'claude-statusline themes' to preview all presets.
+preset = "default"
 
 # Format string controls the layout. Modules are referenced with $name.
 # Styled text groups use [text](style) syntax.
-# When using a theme, you typically don't need to change the format.
+# When using a preset, you typically don't need to change the format.
 format = "$directory | $git_branch | $model | $cost | $context"
 
-# Built-in palettes: "default", "tokyo-night", "gruvbox", "catppuccin"
-# Run 'claude-statusline themes' to preview all themes and palettes.
-palette = "default"
-
-# Custom palette: override or add your own palette colors.
-# Segment keys (seg_fg, dir_bg, etc.) are used by powerline/rounded themes.
-# [palettes.my-theme]
-# accent = "#ff5500"
-# cost_ok = "green"
-# cost_warn = "yellow"
-# cost_high = "red"
-# ctx_ok = "green"
-# ctx_warn = "yellow"
-# ctx_high = "red"
-# seg_fg = "black"
-# dir_bg = "blue"
-# git_bg = "green"
-# model_bg = "magenta"
-# cost_bg = "238"
-# ctx_bg = "236"
-
 # Module configuration. Each module supports format, style, and disabled.
-# Styles: "bold", "dim", "italic", "fg:#hex", "bg:#hex", "palette:name"
+# Styles: "bold", "dim", "italic", "fg:#hex", "bg:#hex", "208"
 
 # [model]
 # format = "{{.DisplayName}}"
@@ -289,32 +221,31 @@ palette = "default"
 
 # [directory]
 # format = "{{.Dir}}"
-# style = "palette:accent"
+# style = "cyan"
 # truncation_length = 3
 
 # [cost]
 # format = '${{printf "%.2f" .TotalCostUSD}}'
-# style = "palette:cost_ok"
+# style = "green"
 # thresholds = [
-#   { above = 1.0, style = "palette:cost_warn" },
-#   { above = 5.0, style = "palette:cost_high" },
+#   { above = 1.0, style = "yellow" },
+#   { above = 5.0, style = "red" },
 # ]
 
 # [context]
 # format = '{{.Bar}} {{printf "%.0f" .UsedPct}}%'
-# style = "palette:ctx_ok"
+# style = "green"
 # bar_width = 5
 # bar_fill = "█"
 # bar_empty = "░"
 # thresholds = [
-#   { above = 50, style = "palette:ctx_warn" },
-#   { above = 70, style = "208" },
-#   { above = 90, style = "palette:ctx_high" },
+#   { above = 50, style = "yellow" },
+#   { above = 90, style = "red" },
 # ]
 
 # [git_branch]
 # format = " {{.Branch}}{{if .InWorktree}} {{end}}"
-# style = "palette:accent"
+# style = "cyan"
 
 # Disabled by default. Set disabled = false and add to format string to enable.
 # [session_timer]
@@ -332,53 +263,4 @@ palette = "default"
 // SampleConfig returns a commented TOML config template for the init command.
 func SampleConfig() string {
 	return sampleConfigTemplate
-}
-
-// ResolveStyle resolves palette references in a style string.
-// It handles both bare "palette:key" tokens and compound styles like
-// "fg:palette:key bg:palette:key bold". Each space-separated token is
-// checked for palette references and resolved independently.
-func (c Config) ResolveStyle(styleStr string) string {
-	if !strings.Contains(styleStr, "palette:") {
-		return styleStr
-	}
-
-	palette, paletteExists := c.Palettes[c.Palette]
-	if !paletteExists {
-		return styleStr
-	}
-
-	var result []string
-
-	for token := range strings.FieldsSeq(styleStr) {
-		result = append(result, resolveToken(token, palette))
-	}
-
-	return strings.Join(result, " ")
-}
-
-// resolveToken resolves a single token against a palette.
-// Handles: "palette:key", "fg:palette:key", "bg:palette:key".
-func resolveToken(token string, palette map[string]string) string {
-	if key, found := strings.CutPrefix(token, "palette:"); found {
-		if value, ok := palette[key]; ok {
-			return value
-		}
-
-		return token
-	}
-
-	for _, prefix := range []string{"fg:", "bg:"} {
-		if rest, found := strings.CutPrefix(token, prefix); found {
-			if key, hasPalette := strings.CutPrefix(rest, "palette:"); hasPalette {
-				if value, ok := palette[key]; ok {
-					return prefix + value
-				}
-
-				return token
-			}
-		}
-	}
-
-	return token
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,6 +86,8 @@ type LinesChangedConfig struct {
 const (
 	defaultTruncationLength = 3
 	defaultBarWidth         = 5
+	defaultBarFill          = "\u2588" // █
+	defaultBarEmpty         = "\u2591" // ░
 	costWarnThreshold       = 5.0
 	ctxWarnThreshold        = 50
 	ctxHighThreshold        = 90
@@ -117,15 +119,15 @@ func Default() Config {
 			Format:   `{{.Bar}} {{printf "%.0f" .UsedPct}}%`,
 			Style:    "green",
 			BarWidth: defaultBarWidth,
-			BarFill:  "\u2588",
-			BarEmpty: "\u2591",
+			BarFill:  defaultBarFill,
+			BarEmpty: defaultBarEmpty,
 			Thresholds: []Threshold{
 				{Above: ctxWarnThreshold, Style: "yellow"},
 				{Above: ctxHighThreshold, Style: "red"},
 			},
 		},
 		GitBranch: GitBranchConfig{
-			Format: "\ue0a0 {{.Branch}}{{if .InWorktree}} \uf0e8{{end}}",
+			Format: iconBranch + " {{.Branch}}{{if .InWorktree}} " + iconWorktree + "{{end}}",
 			Style:  "cyan",
 		},
 		SessionTimer: SessionTimerConfig{
@@ -155,7 +157,7 @@ type presetHeader struct {
 // Loading is two-pass: first the preset field is read to select the base
 // config, then the full file is decoded on top so user overrides layer cleanly.
 func Load(path string) (Config, error) {
-	_, err := os.Stat(path)
+	content, err := os.ReadFile(path)
 	if errors.Is(err, os.ErrNotExist) {
 		return Default(), nil
 	}
@@ -163,10 +165,12 @@ func Load(path string) (Config, error) {
 		return Config{}, err
 	}
 
+	raw := string(content)
+
 	// Pass 1: read preset field.
 	var header presetHeader
 
-	_, err = toml.DecodeFile(path, &header)
+	_, err = toml.Decode(raw, &header)
 	if err != nil {
 		return Config{}, err
 	}
@@ -174,7 +178,7 @@ func Load(path string) (Config, error) {
 	// Pass 2: start from preset base, decode user overrides on top.
 	cfg, _ := ApplyPreset(header.Preset)
 
-	_, err = toml.DecodeFile(path, &cfg)
+	_, err = toml.Decode(raw, &cfg)
 	if err != nil {
 		return Config{}, err
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,28 +12,13 @@ import (
 
 func TestDefault(t *testing.T) {
 	cfg := config.Default()
-	assert.Equal(t, "default", cfg.Theme)
+	assert.Equal(t, "default", cfg.Preset)
 	assert.Equal(t, "$directory | $git_branch | $model | $cost | $context", cfg.Format)
-	assert.Equal(t, "default", cfg.Palette)
+	assert.Equal(t, "cyan", cfg.Directory.Style)
+	assert.Equal(t, "bold", cfg.Model.Style)
 	assert.False(t, cfg.Model.Disabled)
-	assert.False(t, cfg.GitBranch.Disabled)
 	assert.True(t, cfg.SessionTimer.Disabled)
 	assert.True(t, cfg.LinesChanged.Disabled)
-	assert.Equal(t, 5, cfg.Context.BarWidth)
-	assert.Equal(t, "\u2588", cfg.Context.BarFill)
-	assert.Len(t, cfg.Cost.Thresholds, 2)
-	assert.Len(t, cfg.Context.Thresholds, 3)
-}
-
-func TestDefaultPalettes(t *testing.T) {
-	cfg := config.Default()
-	expected := []string{"default", "tokyo-night", "gruvbox", "catppuccin"}
-	for _, name := range expected {
-		palette, ok := cfg.Palettes[name]
-		assert.True(t, ok, "missing built-in palette: %s", name)
-		assert.Len(t, palette, 13, "palette %s should have 13 keys", name)
-	}
-	assert.Len(t, cfg.Palettes, len(expected))
 }
 
 func TestLoadFromFile(t *testing.T) {
@@ -41,83 +26,41 @@ func TestLoadFromFile(t *testing.T) {
 	path := filepath.Join(dir, "config.toml")
 	require.NoError(t, os.WriteFile(path, []byte(`
 format = "$model | $cost"
-palette = "custom"
-
-[palettes.custom]
-accent = "#ff0000"
-
 [model]
-format = "M: {{.DisplayName}}"
-
-[git_branch]
-disabled = false
+style = "italic"
 `), 0o644))
 
 	cfg, err := config.Load(path)
 	require.NoError(t, err)
 	assert.Equal(t, "$model | $cost", cfg.Format)
-	assert.Equal(t, "custom", cfg.Palette)
-	assert.Equal(t, "M: {{.DisplayName}}", cfg.Model.Format)
-	assert.False(t, cfg.GitBranch.Disabled)
-	// Non-overridden fields keep defaults
-	assert.Equal(t, "bold", cfg.Model.Style)
+	assert.Equal(t, "italic", cfg.Model.Style)
 }
 
 func TestLoadMissingFileReturnsDefaults(t *testing.T) {
 	cfg, err := config.Load("/nonexistent/path/config.toml")
 	require.NoError(t, err)
-	assert.Equal(t, "$directory | $git_branch | $model | $cost | $context", cfg.Format)
+	assert.Equal(t, config.Default().Format, cfg.Format)
 }
 
-func TestResolveStyle(t *testing.T) {
-	cfg := config.Default()
-
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{"bare palette ref", "palette:accent", "cyan"},
-		{"no palette ref", "bold green", "bold green"},
-		{"missing key", "palette:nonexistent", "palette:nonexistent"},
-		{"fg palette ref", "fg:palette:accent", "fg:cyan"},
-		{"bg palette ref", "bg:palette:accent", "bg:cyan"},
-		{"compound style", "fg:palette:accent bg:palette:cost_ok bold", "fg:cyan bg:green bold"},
-		{"mixed tokens", "bold palette:accent italic", "bold cyan italic"},
-		{"no palette fast path", "bold italic dim", "bold italic dim"},
-		{"fg non-palette", "fg:#ff0000 bold", "fg:#ff0000 bold"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, cfg.ResolveStyle(tt.input))
-		})
-	}
-}
-
-func TestLoadWithTheme(t *testing.T) {
+func TestLoadWithPreset(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
 	require.NoError(t, os.WriteFile(path, []byte(`
-theme = "powerline"
-palette = "catppuccin"
+preset = "catppuccin"
 `), 0o644))
 
 	cfg, err := config.Load(path)
 	require.NoError(t, err)
-	assert.Equal(t, "powerline", cfg.Theme)
-	assert.Equal(t, "catppuccin", cfg.Palette)
-	// Format should come from the powerline theme, not the default
-	assert.NotEqual(t, "$directory | $git_branch | $model | $cost | $context", cfg.Format)
+	assert.Equal(t, "catppuccin", cfg.Preset)
+	assert.NotEqual(t, config.Default().Format, cfg.Format)
 	assert.Contains(t, cfg.Format, "$directory")
 }
 
-func TestLoadWithThemeAndOverrides(t *testing.T) {
+func TestLoadWithPresetAndOverrides(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
 	require.NoError(t, os.WriteFile(path, []byte(`
-theme = "minimal"
-palette = "gruvbox"
+preset = "pure"
 
 [model]
 format = "CUSTOM: {{.DisplayName}}"
@@ -125,35 +68,31 @@ format = "CUSTOM: {{.DisplayName}}"
 
 	cfg, err := config.Load(path)
 	require.NoError(t, err)
-	assert.Equal(t, "minimal", cfg.Theme)
-	assert.Equal(t, "gruvbox", cfg.Palette)
-	// User override should take precedence over theme's module config
+	assert.Equal(t, "pure", cfg.Preset)
 	assert.Equal(t, "CUSTOM: {{.DisplayName}}", cfg.Model.Format)
 }
 
-func TestLoadWithUnknownTheme(t *testing.T) {
+func TestLoadWithUnknownPreset(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
 	require.NoError(t, os.WriteFile(path, []byte(`
-theme = "nonexistent"
+preset = "nonexistent"
 `), 0o644))
 
 	cfg, err := config.Load(path)
 	require.NoError(t, err)
-	// Unknown theme falls back to default
-	assert.Equal(t, "$directory | $git_branch | $model | $cost | $context", cfg.Format)
+	assert.Equal(t, config.Default().Format, cfg.Format)
 }
 
 func TestSampleConfig(t *testing.T) {
 	sample := config.SampleConfig()
-	assert.Contains(t, sample, `theme = "default"`)
+	assert.Contains(t, sample, `preset = "default"`)
 	assert.Contains(t, sample, "format =")
-	assert.Contains(t, sample, `palette = "default"`)
-	assert.Contains(t, sample, "powerline")
-	assert.Contains(t, sample, "rounded")
 	assert.Contains(t, sample, "minimal")
-	assert.Contains(t, sample, "seg_fg")
-	assert.Contains(t, sample, "dir_bg")
+	assert.Contains(t, sample, "pastel-powerline")
+	assert.Contains(t, sample, "tokyo-night")
+	assert.Contains(t, sample, "gruvbox-rainbow")
+	assert.Contains(t, sample, "catppuccin")
 	assert.Contains(t, sample, "# [model]")
 	assert.Contains(t, sample, "# [cost]")
 	assert.Contains(t, sample, "# [context]")
@@ -162,5 +101,6 @@ func TestSampleConfig(t *testing.T) {
 
 func TestDefaultPath(t *testing.T) {
 	path := config.DefaultPath()
-	assert.Contains(t, path, ".config/claude-statusline/config.toml")
+	assert.Contains(t, path, "claude-statusline")
+	assert.Contains(t, path, "config.toml")
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestDefault(t *testing.T) {
 	cfg := config.Default()
+	assert.Equal(t, "default", cfg.Theme)
 	assert.Equal(t, "$directory | $git_branch | $model | $cost | $context", cfg.Format)
 	assert.Equal(t, "default", cfg.Palette)
 	assert.False(t, cfg.Model.Disabled)
@@ -28,8 +29,9 @@ func TestDefaultPalettes(t *testing.T) {
 	cfg := config.Default()
 	expected := []string{"default", "tokyo-night", "gruvbox", "catppuccin"}
 	for _, name := range expected {
-		_, ok := cfg.Palettes[name]
+		palette, ok := cfg.Palettes[name]
 		assert.True(t, ok, "missing built-in palette: %s", name)
+		assert.Len(t, palette, 13, "palette %s should have 13 keys", name)
 	}
 	assert.Len(t, cfg.Palettes, len(expected))
 }
@@ -69,18 +71,89 @@ func TestLoadMissingFileReturnsDefaults(t *testing.T) {
 
 func TestResolveStyle(t *testing.T) {
 	cfg := config.Default()
-	assert.Equal(t, "cyan", cfg.ResolveStyle("palette:accent"))
-	assert.Equal(t, "bold green", cfg.ResolveStyle("bold green"))
-	assert.Equal(t, "palette:nonexistent", cfg.ResolveStyle("palette:nonexistent"))
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"bare palette ref", "palette:accent", "cyan"},
+		{"no palette ref", "bold green", "bold green"},
+		{"missing key", "palette:nonexistent", "palette:nonexistent"},
+		{"fg palette ref", "fg:palette:accent", "fg:cyan"},
+		{"bg palette ref", "bg:palette:accent", "bg:cyan"},
+		{"compound style", "fg:palette:accent bg:palette:cost_ok bold", "fg:cyan bg:green bold"},
+		{"mixed tokens", "bold palette:accent italic", "bold cyan italic"},
+		{"no palette fast path", "bold italic dim", "bold italic dim"},
+		{"fg non-palette", "fg:#ff0000 bold", "fg:#ff0000 bold"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, cfg.ResolveStyle(tt.input))
+		})
+	}
+}
+
+func TestLoadWithTheme(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+theme = "powerline"
+palette = "catppuccin"
+`), 0o644))
+
+	cfg, err := config.Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, "powerline", cfg.Theme)
+	assert.Equal(t, "catppuccin", cfg.Palette)
+	// Format should come from the powerline theme, not the default
+	assert.NotEqual(t, "$directory | $git_branch | $model | $cost | $context", cfg.Format)
+	assert.Contains(t, cfg.Format, "$directory")
+}
+
+func TestLoadWithThemeAndOverrides(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+theme = "minimal"
+palette = "gruvbox"
+
+[model]
+format = "CUSTOM: {{.DisplayName}}"
+`), 0o644))
+
+	cfg, err := config.Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, "minimal", cfg.Theme)
+	assert.Equal(t, "gruvbox", cfg.Palette)
+	// User override should take precedence over theme's module config
+	assert.Equal(t, "CUSTOM: {{.DisplayName}}", cfg.Model.Format)
+}
+
+func TestLoadWithUnknownTheme(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+theme = "nonexistent"
+`), 0o644))
+
+	cfg, err := config.Load(path)
+	require.NoError(t, err)
+	// Unknown theme falls back to default
+	assert.Equal(t, "$directory | $git_branch | $model | $cost | $context", cfg.Format)
 }
 
 func TestSampleConfig(t *testing.T) {
 	sample := config.SampleConfig()
+	assert.Contains(t, sample, `theme = "default"`)
 	assert.Contains(t, sample, "format =")
 	assert.Contains(t, sample, `palette = "default"`)
-	assert.Contains(t, sample, "tokyo-night")
-	assert.Contains(t, sample, "gruvbox")
-	assert.Contains(t, sample, "catppuccin")
+	assert.Contains(t, sample, "powerline")
+	assert.Contains(t, sample, "rounded")
+	assert.Contains(t, sample, "minimal")
+	assert.Contains(t, sample, "seg_fg")
+	assert.Contains(t, sample, "dir_bg")
 	assert.Contains(t, sample, "# [model]")
 	assert.Contains(t, sample, "# [cost]")
 	assert.Contains(t, sample, "# [context]")

--- a/internal/config/themes.go
+++ b/internal/config/themes.go
@@ -38,16 +38,12 @@ func ApplyPreset(name string) (Config, bool) {
 }
 
 var builtinPresets = map[string]func() Config{
-	"default":          presetDefault,
+	"default":          Default,
 	"minimal":          presetMinimal,
 	"pastel-powerline": presetPastelPowerline,
 	"tokyo-night":      presetTokyoNight,
 	"gruvbox-rainbow":  presetGruvboxRainbow,
 	"catppuccin":       presetCatppuccin,
-}
-
-func presetDefault() Config {
-	return Default()
 }
 
 // Minimal — clean spacing, no separators, no icons, no background colors.
@@ -118,16 +114,16 @@ func powerlineConfig(preset string, format string, segFg string, colors [5]strin
 			Format: ` ${{printf "%.2f" .TotalCostUSD}} `,
 			Style:  segStyle(segFg, colors[3]),
 			Thresholds: []Threshold{
-				{Above: 1.0, Style: "fg:" + thresholds.warn + " bg:" + colors[3]},
-				{Above: costWarnThreshold, Style: "fg:" + thresholds.high + " bg:" + colors[3]},
+				{Above: 1.0, Style: segStyle(thresholds.warn, colors[3])},
+				{Above: costWarnThreshold, Style: segStyle(thresholds.high, colors[3])},
 			},
 		},
 		Context: ContextConfig{
 			Format: ` {{.Bar}} {{printf "%.0f" .UsedPct}}% `, Style: segStyle(segFg, colors[4]),
-			BarWidth: defaultBarWidth, BarFill: "\u2588", BarEmpty: "\u2591",
+			BarWidth: defaultBarWidth, BarFill: defaultBarFill, BarEmpty: defaultBarEmpty,
 			Thresholds: []Threshold{
-				{Above: ctxWarnThreshold, Style: "fg:" + thresholds.warn + " bg:" + colors[4]},
-				{Above: ctxHighThreshold, Style: "fg:" + thresholds.high + " bg:" + colors[4]},
+				{Above: ctxWarnThreshold, Style: segStyle(thresholds.warn, colors[4])},
+				{Above: ctxHighThreshold, Style: segStyle(thresholds.high, colors[4])},
 			},
 		},
 		SessionTimer: SessionTimerConfig{Format: " {{.Elapsed}} ", Style: "dim", Disabled: true},

--- a/internal/config/themes.go
+++ b/internal/config/themes.go
@@ -1,0 +1,177 @@
+package config
+
+import "sort"
+
+const (
+	// Powerline / Nerd Font separator glyphs.
+	plRight    = "\ue0b0" // Powerline right arrow
+	plRoundedL = "\ue0b6" // Rounded left (open)
+	plRoundedR = "\ue0b4" // Rounded right (close)
+)
+
+// ThemeNames returns a sorted list of built-in theme names.
+func ThemeNames() []string {
+	names := make([]string, 0, len(builtinThemes))
+	for name := range builtinThemes {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	return names
+}
+
+// ApplyTheme returns a Config with the named theme applied.
+// If the theme is not found, it falls back to Default().
+// The second return value indicates whether the theme was found.
+func ApplyTheme(name string) (Config, bool) {
+	fn, ok := builtinThemes[name]
+	if !ok {
+		return Default(), false
+	}
+
+	return fn(), true
+}
+
+// builtinThemes maps theme names to constructor functions.
+var builtinThemes = map[string]func() Config{
+	"default":   themeDefault,
+	"powerline": themePowerline,
+	"rounded":   themeRounded,
+	"minimal":   themeMinimal,
+}
+
+func themeDefault() Config {
+	return Default()
+}
+
+// segmentModules returns module configs shared by powerline and rounded themes.
+func segmentModules() (
+	ModelConfig, DirectoryConfig, CostConfig, ContextConfig, GitBranchConfig,
+	SessionTimerConfig, LinesChangedConfig,
+) {
+	model := ModelConfig{
+		Format: " {{.DisplayName}} ",
+		Style:  "fg:palette:seg_fg bg:palette:model_bg bold",
+	}
+
+	directory := DirectoryConfig{
+		Format:           " {{.Dir}} ",
+		Style:            "fg:palette:seg_fg bg:palette:dir_bg",
+		TruncationLength: defaultTruncationLength,
+	}
+
+	cost := CostConfig{
+		Format: ` ${{printf "%.2f" .TotalCostUSD}} `,
+		Style:  "fg:palette:cost_ok bg:palette:cost_bg",
+		Thresholds: []Threshold{
+			{Above: 1.0, Style: "fg:palette:cost_warn bg:palette:cost_bg"},
+			{Above: costWarnThreshold, Style: "fg:palette:cost_high bg:palette:cost_bg"},
+		},
+	}
+
+	context := ContextConfig{
+		Format:   ` {{.Bar}} {{printf "%.0f" .UsedPct}}% `,
+		Style:    "fg:palette:ctx_ok bg:palette:ctx_bg",
+		BarWidth: defaultBarWidth,
+		BarFill:  "\u2588",
+		BarEmpty: "\u2591",
+		Thresholds: []Threshold{
+			{Above: ctxWarnThreshold, Style: "fg:palette:ctx_warn bg:palette:ctx_bg"},
+			{Above: ctxMedThreshold, Style: "fg:208 bg:palette:ctx_bg"},
+			{Above: ctxHighThreshold, Style: "fg:palette:ctx_high bg:palette:ctx_bg"},
+		},
+	}
+
+	gitBranch := GitBranchConfig{
+		Format: " \ue0a0 {{.Branch}}{{if .InWorktree}} \uf0e8{{end}} ",
+		Style:  "fg:palette:seg_fg bg:palette:git_bg",
+	}
+
+	sessionTimer := SessionTimerConfig{
+		Format:   " {{.Elapsed}} ",
+		Style:    "dim",
+		Disabled: true,
+	}
+
+	linesChanged := LinesChangedConfig{
+		Format:       " +{{.Added}} -{{.Removed}} ",
+		AddedStyle:   "green",
+		RemovedStyle: "red",
+		Disabled:     true,
+	}
+
+	return model, directory, cost, context, gitBranch, sessionTimer, linesChanged
+}
+
+func themePowerline() Config {
+	model, directory, cost, context, gitBranch, sessionTimer, linesChanged := segmentModules()
+
+	return Config{
+		Theme:   "powerline",
+		Palette: "default",
+		Format: "[" + plRight + "](fg:palette:dir_bg)" +
+			"$directory" +
+			"[" + plRight + "](fg:palette:dir_bg bg:palette:git_bg)" +
+			"$git_branch" +
+			"[" + plRight + "](fg:palette:git_bg bg:palette:model_bg)" +
+			"$model" +
+			"[" + plRight + "](fg:palette:model_bg bg:palette:cost_bg)" +
+			"$cost" +
+			"[" + plRight + "](fg:palette:cost_bg bg:palette:ctx_bg)" +
+			"$context" +
+			"[" + plRight + "](fg:palette:ctx_bg)",
+		Palettes:     defaultPalettes(),
+		Model:        model,
+		Directory:    directory,
+		Cost:         cost,
+		Context:      context,
+		GitBranch:    gitBranch,
+		SessionTimer: sessionTimer,
+		LinesChanged: linesChanged,
+	}
+}
+
+func themeRounded() Config {
+	model, directory, cost, context, gitBranch, sessionTimer, linesChanged := segmentModules()
+
+	return Config{
+		Theme:   "rounded",
+		Palette: "default",
+		Format: "[" + plRoundedL + "](fg:palette:dir_bg)" +
+			"$directory" +
+			"[" + plRoundedR + "](fg:palette:dir_bg) " +
+			"[" + plRoundedL + "](fg:palette:git_bg)" +
+			"$git_branch" +
+			"[" + plRoundedR + "](fg:palette:git_bg) " +
+			"[" + plRoundedL + "](fg:palette:model_bg)" +
+			"$model" +
+			"[" + plRoundedR + "](fg:palette:model_bg) " +
+			"[" + plRoundedL + "](fg:palette:cost_bg)" +
+			"$cost" +
+			"[" + plRoundedR + "](fg:palette:cost_bg) " +
+			"[" + plRoundedL + "](fg:palette:ctx_bg)" +
+			"$context" +
+			"[" + plRoundedR + "](fg:palette:ctx_bg)",
+		Palettes:     defaultPalettes(),
+		Model:        model,
+		Directory:    directory,
+		Cost:         cost,
+		Context:      context,
+		GitBranch:    gitBranch,
+		SessionTimer: sessionTimer,
+		LinesChanged: linesChanged,
+	}
+}
+
+func themeMinimal() Config {
+	cfg := Default()
+	cfg.Theme = "minimal"
+	cfg.Format = "$directory  $git_branch  $model  $cost  $context"
+	cfg.Directory.Style = "dim"
+	cfg.GitBranch.Format = "{{.Branch}}"
+	cfg.GitBranch.Style = "dim"
+	cfg.Context.Format = `{{printf "%.0f" .UsedPct}}%`
+
+	return cfg
+}

--- a/internal/config/themes.go
+++ b/internal/config/themes.go
@@ -135,7 +135,7 @@ func powerlineConfig(preset string, format string, segFg string, colors [5]strin
 
 // Pastel Powerline — based on Starship's Pastel Powerline preset.
 // Left half-circle cap, arrow transitions, arrow trailing.
-// Colors: purple → pink → peach → blue → dark blue.
+// Colors: pink → peach → light blue → teal → dark blue.
 func presetPastelPowerline() Config {
 	colors := [5]string{"#DA627D", "#FCA17D", "#86BBD8", "#06969A", "#33658A"}
 

--- a/internal/config/themes.go
+++ b/internal/config/themes.go
@@ -4,15 +4,19 @@ import "sort"
 
 const (
 	// Powerline / Nerd Font separator glyphs.
-	plRight    = "\ue0b0" // Powerline right arrow
-	plRoundedL = "\ue0b6" // Rounded left (open)
-	plRoundedR = "\ue0b4" // Rounded right (close)
+	plRight    = "\ue0b0" // Powerline right arrow:
+	plLeftCap  = "\ue0b6" // Powerline left half-circle:
+	plRightCap = "\ue0b4" // Powerline right half-circle:
+	// Git branch icon.
+	iconBranch = "\ue0a0"
+	// Worktree icon.
+	iconWorktree = "\uf0e8"
 )
 
-// ThemeNames returns a sorted list of built-in theme names.
-func ThemeNames() []string {
-	names := make([]string, 0, len(builtinThemes))
-	for name := range builtinThemes {
+// PresetNames returns a sorted list of built-in preset names.
+func PresetNames() []string {
+	names := make([]string, 0, len(builtinPresets))
+	for name := range builtinPresets {
 		names = append(names, name)
 	}
 
@@ -21,11 +25,11 @@ func ThemeNames() []string {
 	return names
 }
 
-// ApplyTheme returns a Config with the named theme applied.
-// If the theme is not found, it falls back to Default().
-// The second return value indicates whether the theme was found.
-func ApplyTheme(name string) (Config, bool) {
-	fn, ok := builtinThemes[name]
+// ApplyPreset returns a Config for the named preset.
+// If the preset is not found, it falls back to Default().
+// The second return value indicates whether the preset was found.
+func ApplyPreset(name string) (Config, bool) {
+	fn, ok := builtinPresets[name]
 	if !ok {
 		return Default(), false
 	}
@@ -33,145 +37,166 @@ func ApplyTheme(name string) (Config, bool) {
 	return fn(), true
 }
 
-// builtinThemes maps theme names to constructor functions.
-var builtinThemes = map[string]func() Config{
-	"default":   themeDefault,
-	"powerline": themePowerline,
-	"rounded":   themeRounded,
-	"minimal":   themeMinimal,
+var builtinPresets = map[string]func() Config{
+	"default":          presetDefault,
+	"minimal":          presetMinimal,
+	"pastel-powerline": presetPastelPowerline,
+	"tokyo-night":      presetTokyoNight,
+	"gruvbox-rainbow":  presetGruvboxRainbow,
+	"catppuccin":       presetCatppuccin,
 }
 
-func themeDefault() Config {
+func presetDefault() Config {
 	return Default()
 }
 
-// segmentModules returns module configs shared by powerline and rounded themes.
-func segmentModules() (
-	ModelConfig, DirectoryConfig, CostConfig, ContextConfig, GitBranchConfig,
-	SessionTimerConfig, LinesChangedConfig,
-) {
-	model := ModelConfig{
-		Format: " {{.DisplayName}} ",
-		Style:  "fg:palette:seg_fg bg:palette:model_bg bold",
-	}
-
-	directory := DirectoryConfig{
-		Format:           " {{.Dir}} ",
-		Style:            "fg:palette:seg_fg bg:palette:dir_bg",
-		TruncationLength: defaultTruncationLength,
-	}
-
-	cost := CostConfig{
-		Format: ` ${{printf "%.2f" .TotalCostUSD}} `,
-		Style:  "fg:palette:cost_ok bg:palette:cost_bg",
-		Thresholds: []Threshold{
-			{Above: 1.0, Style: "fg:palette:cost_warn bg:palette:cost_bg"},
-			{Above: costWarnThreshold, Style: "fg:palette:cost_high bg:palette:cost_bg"},
-		},
-	}
-
-	context := ContextConfig{
-		Format:   ` {{.Bar}} {{printf "%.0f" .UsedPct}}% `,
-		Style:    "fg:palette:ctx_ok bg:palette:ctx_bg",
-		BarWidth: defaultBarWidth,
-		BarFill:  "\u2588",
-		BarEmpty: "\u2591",
-		Thresholds: []Threshold{
-			{Above: ctxWarnThreshold, Style: "fg:palette:ctx_warn bg:palette:ctx_bg"},
-			{Above: ctxMedThreshold, Style: "fg:208 bg:palette:ctx_bg"},
-			{Above: ctxHighThreshold, Style: "fg:palette:ctx_high bg:palette:ctx_bg"},
-		},
-	}
-
-	gitBranch := GitBranchConfig{
-		Format: " \ue0a0 {{.Branch}}{{if .InWorktree}} \uf0e8{{end}} ",
-		Style:  "fg:palette:seg_fg bg:palette:git_bg",
-	}
-
-	sessionTimer := SessionTimerConfig{
-		Format:   " {{.Elapsed}} ",
-		Style:    "dim",
-		Disabled: true,
-	}
-
-	linesChanged := LinesChangedConfig{
-		Format:       " +{{.Added}} -{{.Removed}} ",
-		AddedStyle:   "green",
-		RemovedStyle: "red",
-		Disabled:     true,
-	}
-
-	return model, directory, cost, context, gitBranch, sessionTimer, linesChanged
-}
-
-func themePowerline() Config {
-	model, directory, cost, context, gitBranch, sessionTimer, linesChanged := segmentModules()
-
-	return Config{
-		Theme:   "powerline",
-		Palette: "default",
-		Format: "[" + plRight + "](fg:palette:dir_bg)" +
-			"$directory" +
-			"[" + plRight + "](fg:palette:dir_bg bg:palette:git_bg)" +
-			"$git_branch" +
-			"[" + plRight + "](fg:palette:git_bg bg:palette:model_bg)" +
-			"$model" +
-			"[" + plRight + "](fg:palette:model_bg bg:palette:cost_bg)" +
-			"$cost" +
-			"[" + plRight + "](fg:palette:cost_bg bg:palette:ctx_bg)" +
-			"$context" +
-			"[" + plRight + "](fg:palette:ctx_bg)",
-		Palettes:     defaultPalettes(),
-		Model:        model,
-		Directory:    directory,
-		Cost:         cost,
-		Context:      context,
-		GitBranch:    gitBranch,
-		SessionTimer: sessionTimer,
-		LinesChanged: linesChanged,
-	}
-}
-
-func themeRounded() Config {
-	model, directory, cost, context, gitBranch, sessionTimer, linesChanged := segmentModules()
-
-	return Config{
-		Theme:   "rounded",
-		Palette: "default",
-		Format: "[" + plRoundedL + "](fg:palette:dir_bg)" +
-			"$directory" +
-			"[" + plRoundedR + "](fg:palette:dir_bg) " +
-			"[" + plRoundedL + "](fg:palette:git_bg)" +
-			"$git_branch" +
-			"[" + plRoundedR + "](fg:palette:git_bg) " +
-			"[" + plRoundedL + "](fg:palette:model_bg)" +
-			"$model" +
-			"[" + plRoundedR + "](fg:palette:model_bg) " +
-			"[" + plRoundedL + "](fg:palette:cost_bg)" +
-			"$cost" +
-			"[" + plRoundedR + "](fg:palette:cost_bg) " +
-			"[" + plRoundedL + "](fg:palette:ctx_bg)" +
-			"$context" +
-			"[" + plRoundedR + "](fg:palette:ctx_bg)",
-		Palettes:     defaultPalettes(),
-		Model:        model,
-		Directory:    directory,
-		Cost:         cost,
-		Context:      context,
-		GitBranch:    gitBranch,
-		SessionTimer: sessionTimer,
-		LinesChanged: linesChanged,
-	}
-}
-
-func themeMinimal() Config {
+// Minimal — clean spacing, no separators, no icons, no background colors.
+func presetMinimal() Config {
 	cfg := Default()
-	cfg.Theme = "minimal"
+	cfg.Preset = "minimal"
 	cfg.Format = "$directory  $git_branch  $model  $cost  $context"
-	cfg.Directory.Style = "dim"
+	cfg.Directory.Style = "blue"
 	cfg.GitBranch.Format = "{{.Branch}}"
-	cfg.GitBranch.Style = "dim"
+	cfg.GitBranch.Style = "cyan"
+	cfg.Model.Style = "bold"
+	cfg.Cost.Style = "green"
 	cfg.Context.Format = `{{printf "%.0f" .UsedPct}}%`
+	cfg.Context.Style = "green"
 
 	return cfg
+}
+
+type thresholdColors struct {
+	warn string
+	high string
+}
+
+// capsuleFormat builds a powerline format with a left half-circle cap,
+// right-arrow transitions, and the given trailing glyph.
+func capsuleFormat(colors [5]string, trailing string) string {
+	return "[" + plLeftCap + "](fg:" + colors[0] + ")" +
+		"$directory" +
+		"[" + plRight + "](fg:" + colors[0] + " bg:" + colors[1] + ")" +
+		"$git_branch" +
+		"[" + plRight + "](fg:" + colors[1] + " bg:" + colors[2] + ")" +
+		"$model" +
+		"[" + plRight + "](fg:" + colors[2] + " bg:" + colors[3] + ")" +
+		"$cost" +
+		"[" + plRight + "](fg:" + colors[3] + " bg:" + colors[4] + ")" +
+		"$context" +
+		"[" + trailing + " ](fg:" + colors[4] + ")"
+}
+
+// segStyle builds a style string with optional foreground and required background.
+// When segFg is empty, no fg is set (terminal default foreground).
+func segStyle(segFg string, bgColor string) string {
+	if segFg == "" {
+		return "bg:" + bgColor
+	}
+
+	return "fg:" + segFg + " bg:" + bgColor
+}
+
+// powerlineConfig builds a powerline-style Config with the given format and colors.
+// Pass segFg="" to use terminal default foreground (like Starship's Pastel Powerline).
+func powerlineConfig(preset string, format string, segFg string, colors [5]string, thresholds thresholdColors) Config {
+	return Config{
+		Preset: preset,
+		Format: format,
+		Directory: DirectoryConfig{
+			Format: " {{.Dir}} ", Style: segStyle(segFg, colors[0]),
+			TruncationLength: defaultTruncationLength,
+		},
+		GitBranch: GitBranchConfig{
+			Format: " " + iconBranch + " {{.Branch}}{{if .InWorktree}} " + iconWorktree + "{{end}} ",
+			Style:  segStyle(segFg, colors[1]),
+		},
+		Model: ModelConfig{
+			Format: " {{.DisplayName}} ", Style: segStyle(segFg, colors[2]) + " bold",
+		},
+		Cost: CostConfig{
+			Format: ` ${{printf "%.2f" .TotalCostUSD}} `,
+			Style:  segStyle(segFg, colors[3]),
+			Thresholds: []Threshold{
+				{Above: 1.0, Style: "fg:" + thresholds.warn + " bg:" + colors[3]},
+				{Above: costWarnThreshold, Style: "fg:" + thresholds.high + " bg:" + colors[3]},
+			},
+		},
+		Context: ContextConfig{
+			Format: ` {{.Bar}} {{printf "%.0f" .UsedPct}}% `, Style: segStyle(segFg, colors[4]),
+			BarWidth: defaultBarWidth, BarFill: "\u2588", BarEmpty: "\u2591",
+			Thresholds: []Threshold{
+				{Above: ctxWarnThreshold, Style: "fg:" + thresholds.warn + " bg:" + colors[4]},
+				{Above: ctxHighThreshold, Style: "fg:" + thresholds.high + " bg:" + colors[4]},
+			},
+		},
+		SessionTimer: SessionTimerConfig{Format: " {{.Elapsed}} ", Style: "dim", Disabled: true},
+		LinesChanged: LinesChangedConfig{
+			Format: " +{{.Added}} -{{.Removed}} ", AddedStyle: "green", RemovedStyle: "red", Disabled: true,
+		},
+	}
+}
+
+// Pastel Powerline — based on Starship's Pastel Powerline preset.
+// Left half-circle cap, arrow transitions, arrow trailing.
+// Colors: purple → pink → peach → blue → dark blue.
+func presetPastelPowerline() Config {
+	colors := [5]string{"#DA627D", "#FCA17D", "#86BBD8", "#06969A", "#33658A"}
+
+	return powerlineConfig("pastel-powerline",
+		capsuleFormat(colors, plRight),
+		"", colors,
+		thresholdColors{warn: "#f9e2af", high: "#f38ba8"},
+	)
+}
+
+// Tokyo Night — based on Starship's Tokyo Night preset.
+// Gradient ░▒▓ leading, all rounded half-circle transitions.
+// Colors: bright blue → dark blue-gray → darker → darkest → near-black.
+func presetTokyoNight() Config {
+	colors := [5]string{"#769ff0", "#394260", "#212736", "#1d2230", "#1a1b26"}
+	format := "[\u2591\u2592\u2593](fg:#a3aed2)" +
+		"[" + plRightCap + "](fg:#a3aed2 bg:" + colors[0] + ")" +
+		"$directory" +
+		"[" + plRightCap + "](fg:" + colors[0] + " bg:" + colors[1] + ")" +
+		"$git_branch" +
+		"[" + plRightCap + "](fg:" + colors[1] + " bg:" + colors[2] + ")" +
+		"$model" +
+		"[" + plRightCap + "](fg:" + colors[2] + " bg:" + colors[3] + ")" +
+		"$cost" +
+		"[" + plRightCap + "](fg:" + colors[3] + " bg:" + colors[4] + ")" +
+		"$context" +
+		"[" + plRightCap + " ](fg:" + colors[4] + ")"
+
+	return powerlineConfig("tokyo-night",
+		format,
+		"#e3e5e5", colors,
+		thresholdColors{warn: "#e0af68", high: "#f7768e"},
+	)
+}
+
+// Gruvbox Rainbow — based on Starship's Gruvbox Rainbow preset.
+// Left half-circle cap, arrow transitions, rounded half-circle trailing.
+// Colors: yellow → aqua → blue → gray → dark.
+func presetGruvboxRainbow() Config {
+	colors := [5]string{"#d79921", "#689d6a", "#458588", "#665c54", "#3c3836"}
+
+	return powerlineConfig("gruvbox-rainbow",
+		capsuleFormat(colors, plRightCap),
+		"#fbf1c7", colors,
+		thresholdColors{warn: "#fabd2f", high: "#fb4934"},
+	)
+}
+
+// Catppuccin — based on Starship's Catppuccin Powerline preset (Mocha).
+// Left half-circle cap, arrow transitions, rounded half-circle trailing.
+// Colors: peach → yellow → green → sapphire → lavender.
+func presetCatppuccin() Config {
+	colors := [5]string{"#fab387", "#f9e2af", "#a6e3a1", "#74c7ec", "#b4befe"}
+
+	return powerlineConfig("catppuccin",
+		capsuleFormat(colors, plRightCap),
+		"#11111b", colors,
+		thresholdColors{warn: "#f9e2af", high: "#f38ba8"},
+	)
 }

--- a/internal/config/themes_test.go
+++ b/internal/config/themes_test.go
@@ -7,64 +7,78 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestThemeNames(t *testing.T) {
-	names := config.ThemeNames()
-	assert.Equal(t, []string{"default", "minimal", "powerline", "rounded"}, names)
+func TestPresetNames(t *testing.T) {
+	names := config.PresetNames()
+	assert.Equal(t, []string{
+		"catppuccin", "default", "gruvbox-rainbow", "minimal",
+		"pastel-powerline", "tokyo-night",
+	}, names)
 }
 
-func TestApplyThemeDefault(t *testing.T) {
-	cfg, ok := config.ApplyTheme("default")
+func TestApplyPresetDefault(t *testing.T) {
+	cfg, ok := config.ApplyPreset("default")
 	assert.True(t, ok)
-	assert.Equal(t, "default", cfg.Theme)
+	assert.Equal(t, "default", cfg.Preset)
 	assert.Equal(t, config.Default().Format, cfg.Format)
 }
 
-func TestApplyThemePowerline(t *testing.T) {
-	cfg, ok := config.ApplyTheme("powerline")
+func TestApplyPresetMinimal(t *testing.T) {
+	cfg, ok := config.ApplyPreset("minimal")
 	assert.True(t, ok)
-	assert.Equal(t, "powerline", cfg.Theme)
-	assert.Contains(t, cfg.Format, "\ue0b0")
-	assert.Contains(t, cfg.Format, "$directory")
-	assert.Contains(t, cfg.Format, "$git_branch")
-	assert.Contains(t, cfg.Format, "$model")
-	assert.Contains(t, cfg.Format, "$cost")
-	assert.Contains(t, cfg.Format, "$context")
-	// Module formats should have padding
-	assert.Contains(t, cfg.Directory.Format, " ")
-	assert.Contains(t, cfg.Directory.Style, "bg:palette:dir_bg")
+	assert.Equal(t, "minimal", cfg.Preset)
+	assert.Equal(t, "blue", cfg.Directory.Style)
+	assert.NotContains(t, cfg.Format, "\ue0b0")
+	assert.NotContains(t, cfg.Format, "|")
 }
 
-func TestApplyThemeRounded(t *testing.T) {
-	cfg, ok := config.ApplyTheme("rounded")
+func TestApplyPresetCapsulePowerline(t *testing.T) {
+	for _, name := range []string{"pastel-powerline", "gruvbox-rainbow", "catppuccin"} {
+		t.Run(name, func(t *testing.T) {
+			cfg, ok := config.ApplyPreset(name)
+			assert.True(t, ok)
+			assert.Equal(t, name, cfg.Preset)
+			// Left half-circle cap
+			assert.Contains(t, cfg.Format, "\ue0b6")
+			// Arrow transitions
+			assert.Contains(t, cfg.Format, "\ue0b0")
+			assert.Contains(t, cfg.Format, "$directory")
+			assert.Contains(t, cfg.Format, "$git_branch")
+			assert.Contains(t, cfg.Format, "$model")
+			assert.Contains(t, cfg.Format, "$cost")
+			assert.Contains(t, cfg.Format, "$context")
+			assert.Contains(t, cfg.Directory.Format, " ")
+			assert.Contains(t, cfg.Directory.Style, "bg:")
+		})
+	}
+}
+
+func TestApplyPresetPastelTrailingArrow(t *testing.T) {
+	cfg, _ := config.ApplyPreset("pastel-powerline")
+	// Pastel Powerline ends with right arrow (not rounded half-circle), last color is dark blue
+	assert.Contains(t, cfg.Format, "\ue0b0 ](fg:#33658A)")
+}
+
+func TestApplyPresetGruvboxTrailingRounded(t *testing.T) {
+	cfg, _ := config.ApplyPreset("gruvbox-rainbow")
+	// Gruvbox ends with rounded right half-circle
+	assert.Contains(t, cfg.Format, "\ue0b4 ](fg:#3c3836)")
+}
+
+func TestApplyPresetTokyoNight(t *testing.T) {
+	cfg, ok := config.ApplyPreset("tokyo-night")
 	assert.True(t, ok)
-	assert.Equal(t, "rounded", cfg.Theme)
-	assert.Contains(t, cfg.Format, "\ue0b6")
+	assert.Equal(t, "tokyo-night", cfg.Preset)
+	// Gradient leading
+	assert.Contains(t, cfg.Format, "░▒▓")
+	// All rounded half-circle transitions (not arrows)
 	assert.Contains(t, cfg.Format, "\ue0b4")
+	assert.NotContains(t, cfg.Format, "\ue0b0")
 	assert.Contains(t, cfg.Format, "$directory")
+	assert.Contains(t, cfg.Directory.Style, "bg:")
 }
 
-func TestApplyThemeMinimal(t *testing.T) {
-	cfg, ok := config.ApplyTheme("minimal")
-	assert.True(t, ok)
-	assert.Equal(t, "minimal", cfg.Theme)
-	assert.Equal(t, "$directory  $git_branch  $model  $cost  $context", cfg.Format)
-	// Minimal should not have bg styles
-	assert.Equal(t, "dim", cfg.Directory.Style)
-	assert.Equal(t, "dim", cfg.GitBranch.Style)
-	// Minimal git_branch should not have icons
-	assert.NotContains(t, cfg.GitBranch.Format, "\ue0a0")
-}
-
-func TestApplyThemeUnknown(t *testing.T) {
-	cfg, ok := config.ApplyTheme("nonexistent")
+func TestApplyPresetUnknown(t *testing.T) {
+	cfg, ok := config.ApplyPreset("nonexistent")
 	assert.False(t, ok)
 	assert.Equal(t, config.Default().Format, cfg.Format)
-}
-
-func TestThemesHavePalettes(t *testing.T) {
-	for _, name := range config.ThemeNames() {
-		cfg, ok := config.ApplyTheme(name)
-		assert.True(t, ok, "theme %s should exist", name)
-		assert.Len(t, cfg.Palettes, 4, "theme %s should include all palettes", name)
-	}
 }

--- a/internal/config/themes_test.go
+++ b/internal/config/themes_test.go
@@ -1,0 +1,70 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/felipeelias/claude-statusline/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestThemeNames(t *testing.T) {
+	names := config.ThemeNames()
+	assert.Equal(t, []string{"default", "minimal", "powerline", "rounded"}, names)
+}
+
+func TestApplyThemeDefault(t *testing.T) {
+	cfg, ok := config.ApplyTheme("default")
+	assert.True(t, ok)
+	assert.Equal(t, "default", cfg.Theme)
+	assert.Equal(t, config.Default().Format, cfg.Format)
+}
+
+func TestApplyThemePowerline(t *testing.T) {
+	cfg, ok := config.ApplyTheme("powerline")
+	assert.True(t, ok)
+	assert.Equal(t, "powerline", cfg.Theme)
+	assert.Contains(t, cfg.Format, "\ue0b0")
+	assert.Contains(t, cfg.Format, "$directory")
+	assert.Contains(t, cfg.Format, "$git_branch")
+	assert.Contains(t, cfg.Format, "$model")
+	assert.Contains(t, cfg.Format, "$cost")
+	assert.Contains(t, cfg.Format, "$context")
+	// Module formats should have padding
+	assert.Contains(t, cfg.Directory.Format, " ")
+	assert.Contains(t, cfg.Directory.Style, "bg:palette:dir_bg")
+}
+
+func TestApplyThemeRounded(t *testing.T) {
+	cfg, ok := config.ApplyTheme("rounded")
+	assert.True(t, ok)
+	assert.Equal(t, "rounded", cfg.Theme)
+	assert.Contains(t, cfg.Format, "\ue0b6")
+	assert.Contains(t, cfg.Format, "\ue0b4")
+	assert.Contains(t, cfg.Format, "$directory")
+}
+
+func TestApplyThemeMinimal(t *testing.T) {
+	cfg, ok := config.ApplyTheme("minimal")
+	assert.True(t, ok)
+	assert.Equal(t, "minimal", cfg.Theme)
+	assert.Equal(t, "$directory  $git_branch  $model  $cost  $context", cfg.Format)
+	// Minimal should not have bg styles
+	assert.Equal(t, "dim", cfg.Directory.Style)
+	assert.Equal(t, "dim", cfg.GitBranch.Style)
+	// Minimal git_branch should not have icons
+	assert.NotContains(t, cfg.GitBranch.Format, "\ue0a0")
+}
+
+func TestApplyThemeUnknown(t *testing.T) {
+	cfg, ok := config.ApplyTheme("nonexistent")
+	assert.False(t, ok)
+	assert.Equal(t, config.Default().Format, cfg.Format)
+}
+
+func TestThemesHavePalettes(t *testing.T) {
+	for _, name := range config.ThemeNames() {
+		cfg, ok := config.ApplyTheme(name)
+		assert.True(t, ok, "theme %s should exist", name)
+		assert.Len(t, cfg.Palettes, 4, "theme %s should include all palettes", name)
+	}
+}

--- a/internal/modules/context.go
+++ b/internal/modules/context.go
@@ -38,5 +38,5 @@ func (ContextModule) Render(data input.Data, cfg config.Config) (string, error) 
 
 	winningStyle := resolveThresholdStyle(pct, cfg.Context.Thresholds, cfg.Context.Style)
 
-	return wrapStyle(result, winningStyle, cfg), nil
+	return wrapStyle(result, winningStyle), nil
 }

--- a/internal/modules/context_test.go
+++ b/internal/modules/context_test.go
@@ -70,7 +70,7 @@ func TestContextModule_Render(t *testing.T) {
 		assert.Contains(t, result, "\033[33m")
 	})
 
-	t.Run("threshold above 70 uses 208 style", func(t *testing.T) {
+	t.Run("threshold above 50 still yellow at 75", func(t *testing.T) {
 		data := input.Data{
 			ContextWindow: input.ContextWindow{
 				UsedPercentage: 75.0,
@@ -79,7 +79,7 @@ func TestContextModule_Render(t *testing.T) {
 
 		result, err := modules.ContextModule{}.Render(data, cfg)
 		require.NoError(t, err)
-		assert.Contains(t, result, "\033[38;5;208m")
+		assert.Contains(t, result, "\033[33m")
 	})
 
 	t.Run("threshold above 90 uses high style", func(t *testing.T) {

--- a/internal/modules/cost.go
+++ b/internal/modules/cost.go
@@ -22,5 +22,5 @@ func (CostModule) Render(data input.Data, cfg config.Config) (string, error) {
 
 	winningStyle := resolveThresholdStyle(cost, cfg.Cost.Thresholds, cfg.Cost.Style)
 
-	return wrapStyle(result, winningStyle, cfg), nil
+	return wrapStyle(result, winningStyle), nil
 }

--- a/internal/modules/directory.go
+++ b/internal/modules/directory.go
@@ -57,7 +57,7 @@ func (m DirectoryModule) Render(data input.Data, cfg config.Config) (string, err
 		return "", err
 	}
 
-	return wrapStyle(result, cfg.Directory.Style, cfg), nil
+	return wrapStyle(result, cfg.Directory.Style), nil
 }
 
 // truncatePath keeps the last maxSegments path segments fully and abbreviates earlier ones

--- a/internal/modules/gitbranch.go
+++ b/internal/modules/gitbranch.go
@@ -34,7 +34,7 @@ func (GitBranchModule) Render(data input.Data, cfg config.Config) (string, error
 		return "", err
 	}
 
-	return wrapStyle(result, cfg.GitBranch.Style, cfg), nil
+	return wrapStyle(result, cfg.GitBranch.Style), nil
 }
 
 // gitBranch runs git rev-parse to get the current branch name.

--- a/internal/modules/helpers.go
+++ b/internal/modules/helpers.go
@@ -25,11 +25,9 @@ func renderTemplate(name, format string, data any) (string, error) {
 	return buf.String(), nil
 }
 
-// wrapStyle resolves a style string via the config palette, parses it, and wraps text.
-func wrapStyle(text, styleStr string, cfg config.Config) string {
-	resolved := cfg.ResolveStyle(styleStr)
-
-	return style.Parse(resolved).Wrap(text)
+// wrapStyle parses a style string and wraps text with ANSI codes.
+func wrapStyle(text, styleStr string) string {
+	return style.Parse(styleStr).Wrap(text)
 }
 
 // resolveThresholdStyle evaluates thresholds in order. The last threshold whose

--- a/internal/modules/lines.go
+++ b/internal/modules/lines.go
@@ -20,8 +20,8 @@ func (LinesChangedModule) Render(data input.Data, cfg config.Config) (string, er
 		return "", nil
 	}
 
-	addedStr := wrapStyle(fmt.Sprintf("+%d", added), cfg.LinesChanged.AddedStyle, cfg)
-	removedStr := wrapStyle(fmt.Sprintf("-%d", removed), cfg.LinesChanged.RemovedStyle, cfg)
+	addedStr := wrapStyle(fmt.Sprintf("+%d", added), cfg.LinesChanged.AddedStyle)
+	removedStr := wrapStyle(fmt.Sprintf("-%d", removed), cfg.LinesChanged.RemovedStyle)
 
 	return addedStr + " " + removedStr, nil
 }

--- a/internal/modules/model.go
+++ b/internal/modules/model.go
@@ -23,5 +23,5 @@ func (ModelModule) Render(data input.Data, cfg config.Config) (string, error) {
 		return "", err
 	}
 
-	return wrapStyle(result, cfg.Model.Style, cfg), nil
+	return wrapStyle(result, cfg.Model.Style), nil
 }

--- a/internal/modules/session.go
+++ b/internal/modules/session.go
@@ -33,7 +33,7 @@ func (SessionTimerModule) Render(data input.Data, cfg config.Config) (string, er
 		return "", err
 	}
 
-	return wrapStyle(result, cfg.SessionTimer.Style, cfg), nil
+	return wrapStyle(result, cfg.SessionTimer.Style), nil
 }
 
 // formatDuration converts milliseconds to a human-readable duration.

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -62,9 +62,8 @@ func renderMatch(
 	if loc[2] != -1 && loc[4] != -1 {
 		text := format[loc[2]:loc[3]]
 		styleStr := format[loc[4]:loc[5]]
-		resolved := cfg.ResolveStyle(styleStr)
 
-		return style.Parse(resolved).Wrap(text), nil
+		return style.Parse(styleStr).Wrap(text), nil
 	}
 
 	if loc[6] != -1 {

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -92,9 +92,9 @@ func TestRenderEmptyFormat(t *testing.T) {
 	assert.Empty(t, result)
 }
 
-func TestRenderPaletteStyle(t *testing.T) {
+func TestRenderInlineStyle(t *testing.T) {
 	cfg := config.Default()
-	cfg.Format = "[text](palette:accent)"
+	cfg.Format = "[text](cyan)"
 	result, err := render.Render(cfg, input.Data{})
 	require.NoError(t, err)
 	assert.Contains(t, result, "\033[36m")

--- a/internal/style/style.go
+++ b/internal/style/style.go
@@ -109,6 +109,11 @@ func parseFg(value string) ([]string, bool) {
 		return []string{strconv.Itoa(code)}, true
 	}
 
+	n, err := strconv.Atoi(value)
+	if err == nil && n >= 0 && n <= 255 {
+		return []string{fmt.Sprintf("38;5;%d", n)}, true
+	}
+
 	return nil, false
 }
 
@@ -119,6 +124,11 @@ func parseBg(value string) ([]string, bool) {
 
 	if code, ok := namedColors[value]; ok {
 		return []string{strconv.Itoa(code + ansiFgToBgOffset)}, true
+	}
+
+	n, err := strconv.Atoi(value)
+	if err == nil && n >= 0 && n <= 255 {
+		return []string{fmt.Sprintf("48;5;%d", n)}, true
 	}
 
 	return nil, false

--- a/internal/style/style_test.go
+++ b/internal/style/style_test.go
@@ -69,6 +69,24 @@ func TestWrapFgNamedPrefix(t *testing.T) {
 	assert.Equal(t, "\033[31mhi\033[0m", s.Wrap("hi"))
 }
 
+func TestWrapFg256Color(t *testing.T) {
+	s := style.Parse("fg:208")
+	assert.Equal(t, "\033[38;5;208mhi\033[0m", s.Wrap("hi"))
+}
+
+func TestWrapBg256Color(t *testing.T) {
+	s := style.Parse("bg:238")
+	assert.Equal(t, "\033[48;5;238mhi\033[0m", s.Wrap("hi"))
+}
+
+func TestWrapFgBg256ColorCombined(t *testing.T) {
+	s := style.Parse("fg:208 bg:238 bold")
+	result := s.Wrap("hi")
+	assert.Contains(t, result, "38;5;208")
+	assert.Contains(t, result, "48;5;238")
+	assert.Contains(t, result, "1")
+}
+
 func TestWrapBgNamed(t *testing.T) {
 	tests := []struct{ name, style, expected string }{
 		{"bg:red", "bg:red", "\033[41mhi\033[0m"},

--- a/main_test.go
+++ b/main_test.go
@@ -16,6 +16,13 @@ import (
 
 var testBinary string
 
+const mockJSON = `{
+	"model": {"display_name": "Claude Opus 4"},
+	"cwd": "/tmp/test",
+	"cost": {"total_cost_usd": 0.42},
+	"context_window": {"used_percentage": 42.5}
+}`
+
 func TestMain(m *testing.M) {
 	tmp, err := os.MkdirTemp("", "claude-statusline-test-*")
 	if err != nil {
@@ -38,15 +45,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestEndToEnd(t *testing.T) {
-	jsonInput := `{
-		"model": {"display_name": "Claude Opus 4"},
-		"cwd": "/tmp/test",
-		"cost": {"total_cost_usd": 0.42},
-		"context_window": {"used_percentage": 42.5}
-	}`
-
 	cmd := exec.CommandContext(context.Background(), testBinary)
-	cmd.Stdin = strings.NewReader(jsonInput)
+	cmd.Stdin = strings.NewReader(mockJSON)
 	out, err := cmd.Output()
 	require.NoError(t, err)
 
@@ -58,15 +58,8 @@ func TestEndToEnd(t *testing.T) {
 }
 
 func TestEndToEndPromptSubcommand(t *testing.T) {
-	jsonInput := `{
-		"model": {"display_name": "Claude Opus 4"},
-		"cwd": "/tmp/test",
-		"cost": {"total_cost_usd": 0.42},
-		"context_window": {"used_percentage": 42.5}
-	}`
-
 	cmd := exec.CommandContext(context.Background(), testBinary, "prompt")
-	cmd.Stdin = strings.NewReader(jsonInput)
+	cmd.Stdin = strings.NewReader(mockJSON)
 	out, err := cmd.Output()
 	require.NoError(t, err)
 
@@ -96,6 +89,7 @@ func TestEndToEndInitCommand(t *testing.T) {
 
 	content, err := os.ReadFile(configPath)
 	require.NoError(t, err)
+	assert.Contains(t, string(content), `theme = "default"`)
 	assert.Contains(t, string(content), "format =")
 	assert.Contains(t, string(content), `palette = "default"`)
 }
@@ -118,10 +112,33 @@ func TestEndToEndThemesCommand(t *testing.T) {
 
 	result := string(out)
 	assert.Contains(t, result, "current:")
+	assert.Contains(t, result, "--- default ---")
+	assert.Contains(t, result, "--- powerline ---")
+	assert.Contains(t, result, "--- rounded ---")
+	assert.Contains(t, result, "--- minimal ---")
 	assert.Contains(t, result, "default:")
 	assert.Contains(t, result, "tokyo-night:")
 	assert.Contains(t, result, "gruvbox:")
 	assert.Contains(t, result, "catppuccin:")
+}
+
+func TestEndToEndWithThemeConfig(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	err := os.WriteFile(configPath, []byte(`
+theme = "powerline"
+palette = "catppuccin"
+`), 0o644)
+	require.NoError(t, err)
+
+	cmd := exec.CommandContext(context.Background(), testBinary, "--config", configPath)
+	cmd.Stdin = strings.NewReader(mockJSON)
+	out, err := cmd.Output()
+	require.NoError(t, err)
+
+	result := string(out)
+	assert.Contains(t, result, "Claude Opus 4")
+	assert.Contains(t, result, "$0.42")
 }
 
 func TestEndToEndVersion(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -89,9 +89,8 @@ func TestEndToEndInitCommand(t *testing.T) {
 
 	content, err := os.ReadFile(configPath)
 	require.NoError(t, err)
-	assert.Contains(t, string(content), `theme = "default"`)
+	assert.Contains(t, string(content), `preset = "default"`)
 	assert.Contains(t, string(content), "format =")
-	assert.Contains(t, string(content), `palette = "default"`)
 }
 
 func TestEndToEndTestCommand(t *testing.T) {
@@ -112,22 +111,19 @@ func TestEndToEndThemesCommand(t *testing.T) {
 
 	result := string(out)
 	assert.Contains(t, result, "current:")
-	assert.Contains(t, result, "--- default ---")
-	assert.Contains(t, result, "--- powerline ---")
-	assert.Contains(t, result, "--- rounded ---")
-	assert.Contains(t, result, "--- minimal ---")
 	assert.Contains(t, result, "default:")
+	assert.Contains(t, result, "minimal:")
+	assert.Contains(t, result, "pastel-powerline:")
 	assert.Contains(t, result, "tokyo-night:")
-	assert.Contains(t, result, "gruvbox:")
+	assert.Contains(t, result, "gruvbox-rainbow:")
 	assert.Contains(t, result, "catppuccin:")
 }
 
-func TestEndToEndWithThemeConfig(t *testing.T) {
+func TestEndToEndWithPresetConfig(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.toml")
 	err := os.WriteFile(configPath, []byte(`
-theme = "powerline"
-palette = "catppuccin"
+preset = "catppuccin"
 `), 0o644)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary

- Add 4 built-in themes (`default`, `powerline`, `rounded`, `minimal`) that control visual structure (separators, padding, icons) independently from color palettes
- Add `theme` field to config with two-pass loading: theme sets the base config, user TOML overrides layer on top
- Enhance `ResolveStyle` to handle compound palette references (`fg:palette:key bg:palette:key bold`)
- Fix `parseFg`/`parseBg` to support 256-color codes (`fg:208`, `bg:238`)
- Expand all 4 palettes with 6 new segment keys (`seg_fg`, `dir_bg`, `git_bg`, `model_bg`, `cost_bg`, `ctx_bg`)
- Update `themes` command to show full theme x palette matrix (4 themes x 4 palettes)

## Test plan

- [x] `go test ./...` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `claude-statusline test` — default theme renders as before
- [x] `claude-statusline themes` — shows 4 themes x 4 palettes matrix
- [x] Config with `theme = "powerline"` + `palette = "catppuccin"` renders powerline arrows with Catppuccin colors
- [x] Config with `theme = "minimal"` renders clean spacing, no icons
- [x] Backwards compatible: existing configs without `theme` field still work