### PR TITLE
fix: improve themes command readability

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -168,7 +168,7 @@ func themesCommand() *ucli.Command {
 					return fmt.Errorf("rendering %s: %w", name, err)
 				}
 
-				_, _ = fmt.Fprintf(writer, "%-18s %s\n", name+":", output)
+				_, _ = fmt.Fprintf(writer, "%s:\n  %s\n\n", name, output)
 			}
 
 			return nil


### PR DESCRIPTION
## Summary

- Display each preset on its own line with indented output below, matching the `current:` format
- Add blank line between presets for visual separation

## Test plan

- [x] `go test ./internal/cli/...` passes
- [x] `claude-statusline themes` verified locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated themes command output formatting from two-column alignment to a stacked block layout for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->