### PR TITLE
refactor: expose Hours/Minutes/Seconds template fields in session_timer

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,7 +131,7 @@ func Default() Config {
 			Style:  "cyan",
 		},
 		SessionTimer: SessionTimerConfig{
-			Format:   "{{.Elapsed}}",
+			Format:   "{{if .Hours}}{{.Hours}}h{{end}}{{printf \"%02d\" .Minutes}}m{{printf \"%02d\" .Seconds}}s",
 			Style:    "dim",
 			Disabled: true,
 		},
@@ -254,7 +254,7 @@ format = "$directory | $git_branch | $model | $cost | $context"
 # Disabled by default. Set disabled = false and add to format string to enable.
 # [session_timer]
 # disabled = false
-# format = "{{.Elapsed}}"
+# format = "{{if .Hours}}{{.Hours}}h{{end}}{{printf \"%02d\" .Minutes}}m{{printf \"%02d\" .Seconds}}s"
 # style = "dim"
 
 # [lines_changed]

--- a/internal/config/themes.go
+++ b/internal/config/themes.go
@@ -126,7 +126,11 @@ func powerlineConfig(preset string, format string, segFg string, colors [5]strin
 				{Above: ctxHighThreshold, Style: segStyle(thresholds.high, colors[4])},
 			},
 		},
-		SessionTimer: SessionTimerConfig{Format: " {{if .Hours}}{{.Hours}}h{{end}}{{printf \"%02d\" .Minutes}}m{{printf \"%02d\" .Seconds}}s ", Style: "dim", Disabled: true},
+		SessionTimer: SessionTimerConfig{
+			Format:   " {{if .Hours}}{{.Hours}}h{{end}}{{printf \"%02d\" .Minutes}}m{{printf \"%02d\" .Seconds}}s ",
+			Style:    "dim",
+			Disabled: true,
+		},
 		LinesChanged: LinesChangedConfig{
 			Format: " +{{.Added}} -{{.Removed}} ", AddedStyle: "green", RemovedStyle: "red", Disabled: true,
 		},

--- a/internal/config/themes.go
+++ b/internal/config/themes.go
@@ -126,7 +126,7 @@ func powerlineConfig(preset string, format string, segFg string, colors [5]strin
 				{Above: ctxHighThreshold, Style: segStyle(thresholds.high, colors[4])},
 			},
 		},
-		SessionTimer: SessionTimerConfig{Format: " {{.Elapsed}} ", Style: "dim", Disabled: true},
+		SessionTimer: SessionTimerConfig{Format: " {{if .Hours}}{{.Hours}}h{{end}}{{printf \"%02d\" .Minutes}}m{{printf \"%02d\" .Seconds}}s ", Style: "dim", Disabled: true},
 		LinesChanged: LinesChangedConfig{
 			Format: " +{{.Added}} -{{.Removed}} ", AddedStyle: "green", RemovedStyle: "red", Disabled: true,
 		},

--- a/internal/modules/session.go
+++ b/internal/modules/session.go
@@ -1,8 +1,6 @@
 package modules
 
 import (
-	"fmt"
-
 	"github.com/felipeelias/claude-statusline/internal/config"
 	"github.com/felipeelias/claude-statusline/internal/input"
 )
@@ -24,9 +22,20 @@ func (SessionTimerModule) Render(data input.Data, cfg config.Config) (string, er
 		return "", nil
 	}
 
-	elapsed := formatDuration(ms)
+	totalSeconds := ms / msPerSecond
+	hours := totalSeconds / secondsPerHour
+	minutes := (totalSeconds % secondsPerHour) / secondsPerMinute
+	seconds := totalSeconds % secondsPerMinute
 
-	templateData := struct{ Elapsed string }{Elapsed: elapsed}
+	templateData := struct {
+		Hours   int
+		Minutes int
+		Seconds int
+	}{
+		Hours:   hours,
+		Minutes: minutes,
+		Seconds: seconds,
+	}
 
 	result, err := renderTemplate("session_timer", cfg.SessionTimer.Format, templateData)
 	if err != nil {
@@ -34,19 +43,4 @@ func (SessionTimerModule) Render(data input.Data, cfg config.Config) (string, er
 	}
 
 	return wrapStyle(result, cfg.SessionTimer.Style), nil
-}
-
-// formatDuration converts milliseconds to a human-readable duration.
-// If >= 1 hour: H:MM:SS (e.g. 1:05:03), else: M:SS (e.g. 5:03).
-func formatDuration(ms int) string {
-	totalSeconds := ms / msPerSecond
-	hours := totalSeconds / secondsPerHour
-	minutes := (totalSeconds % secondsPerHour) / secondsPerMinute
-	seconds := totalSeconds % secondsPerMinute
-
-	if hours > 0 {
-		return fmt.Sprintf("%d:%02d:%02d", hours, minutes, seconds)
-	}
-
-	return fmt.Sprintf("%d:%02d", minutes, seconds)
 }

--- a/internal/modules/session_test.go
+++ b/internal/modules/session_test.go
@@ -25,7 +25,7 @@ func TestSessionTimerModule_Render(t *testing.T) {
 
 		result, err := modules.SessionTimerModule{}.Render(data, cfg)
 		require.NoError(t, err)
-		assert.Contains(t, result, "1:01:01")
+		assert.Contains(t, result, "1h01m01s")
 	})
 
 	t.Run("formats minutes seconds without hours", func(t *testing.T) {
@@ -35,7 +35,7 @@ func TestSessionTimerModule_Render(t *testing.T) {
 
 		result, err := modules.SessionTimerModule{}.Render(data, cfg)
 		require.NoError(t, err)
-		assert.Contains(t, result, "2:05")
+		assert.Contains(t, result, "02m05s")
 	})
 
 	t.Run("zero duration returns empty string", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Replace pre-formatted `{{.Elapsed}}` with individual `{{.Hours}}`, `{{.Minutes}}`, `{{.Seconds}}` template fields
- Default format renders as `03m00s` or `1h05m03s` (hours omitted when zero)
- Users can customize the duration format via the template (e.g. `{{.Hours}}:{{printf "%02d" .Minutes}}:{{printf "%02d" .Seconds}}`)

## Test plan

- [x] `go test ./...` passes
- [x] `claude-statusline test` verified locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Session timer display format updated to show a more granular time breakdown, with hours (when applicable), minutes, and seconds formatted as two-digit values for improved visibility and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->