### PR TITLE
feat: add git status indicators to git_branch module

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -761,7 +761,17 @@ disabled = true
 
 ## Priority: Medium
 
-### 18. Multi-line layout
+### 18. Timeout for git subprocess calls
+
+The `git_branch` module runs `git status --porcelain=v2 --branch` (detailed mode) or `git rev-parse --abbrev-ref HEAD` (simple mode) without a timeout. On network-mounted repos or hung git processes, this could block the status line indefinitely.
+
+**Change:**
+
+Replace `exec.Command` with `exec.CommandContext` using a `context.WithTimeout` (e.g., 5 seconds). Apply to both `gitBranchSimple` and `gitStatusDetailed` in `internal/modules/gitbranch.go`. On timeout, return empty output (same as a non-git directory).
+
+---
+
+### 19. Multi-line layout
 
 Allow the format string to define multiple lines using `\n` as a line separator. Claude Code's status line natively supports multiple output lines — each `echo`/line in the output becomes a separate row.
 
@@ -787,7 +797,7 @@ Line 2: $0.42 | ███░░ 60% | 05m23s
 
 ---
 
-### 19. Flex separator
+### 20. Flex separator
 
 A special token `$fill` in the format string that expands to fill available terminal width, enabling right-aligned segments.
 
@@ -813,7 +823,7 @@ This would render:
 
 ---
 
-### 20. Message count module
+### 21. Message count module
 
 A new `messages` module that shows the number of user and assistant messages in the current session. Reads from the transcript JSONL file.
 
@@ -848,7 +858,7 @@ disabled = true
 
 ---
 
-### 21. Exceeds 200k indicator
+### 22. Exceeds 200k indicator
 
 Add a `{{.Exceeds200k}}` boolean field to the context module that is true when `exceeds_200k_tokens` is true in the JSON payload. This warns when the last API response exceeded 200k total tokens.
 
@@ -871,7 +881,7 @@ format = '{{.Bar}} {{printf "%.0f" .UsedPct}}%{{if .Exceeds200k}} LARGE{{end}}'
 
 ## Priority: Low
 
-### 22. Usage API integration
+### 23. Usage API integration
 
 Query the Anthropic OAuth API (`api.anthropic.com/api/oauth/usage`) to show real-time 5-hour block and 7-day usage percentages.
 
@@ -901,7 +911,7 @@ cache_ttl_seconds = 300
 
 ---
 
-### 23. Skills / hooks tracking
+### 24. Skills / hooks tracking
 
 Track which Claude Code tools/skills are invoked during a session by integrating with Claude Code hooks.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,6 +66,7 @@ type GitBranchConfig struct {
 	Format   string `toml:"format"`
 	Style    string `toml:"style"`
 	Disabled bool   `toml:"disabled"`
+	Mode     string `toml:"mode"`
 }
 
 // SessionTimerConfig holds session timer module settings.
@@ -127,8 +128,9 @@ func Default() Config {
 			},
 		},
 		GitBranch: GitBranchConfig{
-			Format: iconBranch + " {{.Branch}}{{if .InWorktree}} " + iconWorktree + "{{end}}",
+			Format: iconBranch + " {{.Branch}}{{if .InWorktree}} " + iconWorktree + "{{end}}{{if .IsDirty}} *{{end}}{{if .Ahead}} \u2191{{.Ahead}}{{end}}{{if .Behind}} \u2193{{.Behind}}{{end}}",
 			Style:  "cyan",
+			Mode:   "detailed",
 		},
 		SessionTimer: SessionTimerConfig{
 			Format:   "{{if .Hours}}{{.Hours}}h{{end}}{{printf \"%02d\" .Minutes}}m{{printf \"%02d\" .Seconds}}s",
@@ -248,7 +250,8 @@ format = "$directory | $git_branch | $model | $cost | $context"
 # ]
 
 # [git_branch]
-# format = " {{.Branch}}{{if .InWorktree}} {{end}}"
+# mode = "detailed"  # "detailed" (default) or "simple" (fast, branch name only)
+# format = " {{.Branch}}{{if .InWorktree}} {{end}}{{if .IsDirty}} *{{end}}{{if .Ahead}} ↑{{.Ahead}}{{end}}{{if .Behind}} ↓{{.Behind}}{{end}}"
 # style = "cyan"
 
 # Disabled by default. Set disabled = false and add to format string to enable.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -128,9 +128,13 @@ func Default() Config {
 			},
 		},
 		GitBranch: GitBranchConfig{
-			Format: iconBranch + " {{.Branch}}{{if .InWorktree}} " + iconWorktree + "{{end}}{{if .IsDirty}} *{{end}}{{if .Ahead}} \u2191{{.Ahead}}{{end}}{{if .Behind}} \u2193{{.Behind}}{{end}}",
-			Style:  "cyan",
-			Mode:   "detailed",
+			Format: iconBranch + " {{.Branch}}" +
+				"{{if .InWorktree}} " + iconWorktree + "{{end}}" +
+				"{{if .IsDirty}} *{{end}}" +
+				"{{if .Ahead}} \u2191{{.Ahead}}{{end}}" +
+				"{{if .Behind}} \u2193{{.Behind}}{{end}}",
+			Style: "cyan",
+			Mode:  "detailed",
 		},
 		SessionTimer: SessionTimerConfig{
 			Format:   "{{if .Hours}}{{.Hours}}h{{end}}{{printf \"%02d\" .Minutes}}m{{printf \"%02d\" .Seconds}}s",
@@ -250,9 +254,10 @@ format = "$directory | $git_branch | $model | $cost | $context"
 # ]
 
 # [git_branch]
-# mode = "detailed"  # "detailed" (default) or "simple" (fast, branch name only)
-# format = " {{.Branch}}{{if .InWorktree}} {{end}}{{if .IsDirty}} *{{end}}{{if .Ahead}} ↑{{.Ahead}}{{end}}{{if .Behind}} ↓{{.Behind}}{{end}}"
+# mode = "detailed"  # "detailed" (default) or "simple" (fast, branch only)
 # style = "cyan"
+# Template fields: Branch, InWorktree, IsDirty, IsClean,
+#   Staged, Modified, Untracked, Ahead, Behind, Conflicts
 
 # Disabled by default. Set disabled = false and add to format string to enable.
 # [session_timer]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,7 +66,7 @@ type GitBranchConfig struct {
 	Format   string `toml:"format"`
 	Style    string `toml:"style"`
 	Disabled bool   `toml:"disabled"`
-	Mode     string `toml:"mode"`
+	Mode     string `toml:"mode"` // "detailed" (default) or "simple"
 }
 
 // SessionTimerConfig holds session timer module settings.

--- a/internal/config/themes.go
+++ b/internal/config/themes.go
@@ -54,6 +54,7 @@ func presetMinimal() Config {
 	cfg.Directory.Style = "blue"
 	cfg.GitBranch.Format = "{{.Branch}}"
 	cfg.GitBranch.Style = "cyan"
+	cfg.GitBranch.Mode = "simple"
 	cfg.Model.Style = "bold"
 	cfg.Cost.Style = "green"
 	cfg.Context.Format = `{{printf "%.0f" .UsedPct}}%`
@@ -104,8 +105,9 @@ func powerlineConfig(preset string, format string, segFg string, colors [5]strin
 			TruncationLength: defaultTruncationLength,
 		},
 		GitBranch: GitBranchConfig{
-			Format: " " + iconBranch + " {{.Branch}}{{if .InWorktree}} " + iconWorktree + "{{end}} ",
+			Format: " " + iconBranch + " {{.Branch}}{{if .InWorktree}} " + iconWorktree + "{{end}}{{if .IsDirty}} *{{end}}{{if .Ahead}} \u2191{{.Ahead}}{{end}}{{if .Behind}} \u2193{{.Behind}}{{end}} ",
 			Style:  segStyle(segFg, colors[1]),
+			Mode:   "detailed",
 		},
 		Model: ModelConfig{
 			Format: " {{.DisplayName}} ", Style: segStyle(segFg, colors[2]) + " bold",

--- a/internal/config/themes.go
+++ b/internal/config/themes.go
@@ -105,9 +105,13 @@ func powerlineConfig(preset string, format string, segFg string, colors [5]strin
 			TruncationLength: defaultTruncationLength,
 		},
 		GitBranch: GitBranchConfig{
-			Format: " " + iconBranch + " {{.Branch}}{{if .InWorktree}} " + iconWorktree + "{{end}}{{if .IsDirty}} *{{end}}{{if .Ahead}} \u2191{{.Ahead}}{{end}}{{if .Behind}} \u2193{{.Behind}}{{end}} ",
-			Style:  segStyle(segFg, colors[1]),
-			Mode:   "detailed",
+			Format: " " + iconBranch + " {{.Branch}}" +
+				"{{if .InWorktree}} " + iconWorktree + "{{end}}" +
+				"{{if .IsDirty}} *{{end}}" +
+				"{{if .Ahead}} \u2191{{.Ahead}}{{end}}" +
+				"{{if .Behind}} \u2193{{.Behind}}{{end}} ",
+			Style: segStyle(segFg, colors[1]),
+			Mode:  "detailed",
 		},
 		Model: ModelConfig{
 			Format: " {{.DisplayName}} ", Style: segStyle(segFg, colors[2]) + " bold",

--- a/internal/modules/gitbranch.go
+++ b/internal/modules/gitbranch.go
@@ -8,25 +8,43 @@ import (
 	"github.com/felipeelias/claude-statusline/internal/input"
 )
 
-// GitBranchModule renders the current git branch name with optional worktree indicator.
+// GitBranchModule renders the current git branch name with optional status indicators.
 type GitBranchModule struct{}
 
 func (GitBranchModule) Name() string { return "git_branch" }
 
 func (GitBranchModule) Render(data input.Data, cfg config.Config) (string, error) {
-	branch := gitBranch(data.Cwd)
-	if branch == "" {
-		return "", nil
-	}
-
 	inWorktree := data.Worktree != nil && data.Worktree.Name != ""
 
-	templateData := struct {
-		Branch     string
-		InWorktree bool
-	}{
-		Branch:     branch,
-		InWorktree: inWorktree,
+	var templateData gitBranchTemplateData
+
+	if cfg.GitBranch.Mode == "simple" {
+		branch := gitBranchSimple(data.Cwd)
+		if branch == "" {
+			return "", nil
+		}
+		templateData = gitBranchTemplateData{
+			Branch:     branch,
+			InWorktree: inWorktree,
+		}
+	} else {
+		status := gitStatusDetailed(data.Cwd)
+		if status.Branch == "" {
+			return "", nil
+		}
+		dirty := status.Staged > 0 || status.Modified > 0 || status.Untracked > 0 || status.Conflicts > 0
+		templateData = gitBranchTemplateData{
+			Branch:     status.Branch,
+			InWorktree: inWorktree,
+			Staged:     status.Staged,
+			Modified:   status.Modified,
+			Untracked:  status.Untracked,
+			Ahead:      status.Ahead,
+			Behind:     status.Behind,
+			Conflicts:  status.Conflicts,
+			IsDirty:    dirty,
+			IsClean:    !dirty,
+		}
 	}
 
 	result, err := renderTemplate("git_branch", cfg.GitBranch.Format, templateData)
@@ -37,9 +55,22 @@ func (GitBranchModule) Render(data input.Data, cfg config.Config) (string, error
 	return wrapStyle(result, cfg.GitBranch.Style), nil
 }
 
-// gitBranch runs git rev-parse to get the current branch name.
+type gitBranchTemplateData struct {
+	Branch     string
+	InWorktree bool
+	Staged     int
+	Modified   int
+	Untracked  int
+	Ahead      int
+	Behind     int
+	Conflicts  int
+	IsDirty    bool
+	IsClean    bool
+}
+
+// gitBranchSimple runs git rev-parse to get the current branch name.
 // Returns empty string if the directory is not a git repo or git is not installed.
-func gitBranch(cwd string) string {
+func gitBranchSimple(cwd string) string {
 	//nolint:noctx // no context available in module interface
 	cmd := exec.Command("git", "-C", cwd, "rev-parse", "--abbrev-ref", "HEAD")
 	out, err := cmd.Output()
@@ -48,4 +79,17 @@ func gitBranch(cwd string) string {
 	}
 
 	return strings.TrimSpace(string(out))
+}
+
+// gitStatusDetailed runs git status --porcelain=v2 --branch and parses the output.
+// Returns zero-value GitStatus if the directory is not a git repo or git is not installed.
+func gitStatusDetailed(cwd string) GitStatus {
+	//nolint:noctx // no context available in module interface
+	cmd := exec.Command("git", "-C", cwd, "status", "--porcelain=v2", "--branch")
+	out, err := cmd.Output()
+	if err != nil {
+		return GitStatus{}
+	}
+
+	return ParsePorcelainV2(string(out))
 }

--- a/internal/modules/gitbranch_test.go
+++ b/internal/modules/gitbranch_test.go
@@ -93,3 +93,103 @@ func TestGitBranchModule_NoWorktreeIcon(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotContains(t, result, string('\uf0e8'))
 }
+
+func TestGitBranchModule_DetailedMode_CleanRepo(t *testing.T) {
+	cfg := config.Default()
+	dir := initGitRepo(t)
+
+	data := input.Data{Cwd: dir}
+	result, err := modules.GitBranchModule{}.Render(data, cfg)
+	require.NoError(t, err)
+	assert.NotContains(t, result, "*")
+	assert.NotContains(t, result, "\u2191")
+	assert.NotContains(t, result, "\u2193")
+}
+
+func TestGitBranchModule_DetailedMode_DirtyIndicator(t *testing.T) {
+	cfg := config.Default()
+	dir := initGitRepo(t)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "dirty.txt"), []byte("dirty"), 0644))
+
+	data := input.Data{Cwd: dir}
+	result, err := modules.GitBranchModule{}.Render(data, cfg)
+	require.NoError(t, err)
+	assert.Contains(t, result, "*")
+}
+
+func TestGitBranchModule_DetailedMode_StagedIsDirty(t *testing.T) {
+	cfg := config.Default()
+	dir := initGitRepo(t)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "staged.txt"), []byte("new"), 0644))
+	cmd := exec.CommandContext(t.Context(), "git", "-C", dir, "add", "staged.txt")
+	require.NoError(t, cmd.Run())
+
+	data := input.Data{Cwd: dir}
+	result, err := modules.GitBranchModule{}.Render(data, cfg)
+	require.NoError(t, err)
+	assert.Contains(t, result, "*")
+}
+
+func TestGitBranchModule_DetailedMode_AheadBehind(t *testing.T) {
+	cfg := config.Default()
+	origin := initGitRepo(t)
+
+	dir := t.TempDir()
+	cmd := exec.CommandContext(t.Context(), "git", "clone", origin, dir)
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null")
+	require.NoError(t, cmd.Run())
+
+	cmd = exec.CommandContext(t.Context(), "git", "-C", dir, "config", "user.email", "test@test.com")
+	require.NoError(t, cmd.Run())
+	cmd = exec.CommandContext(t.Context(), "git", "-C", dir, "config", "user.name", "Test")
+	require.NoError(t, cmd.Run())
+
+	cmd = exec.CommandContext(t.Context(), "git", "-C", dir, "commit", "--allow-empty", "-m", "ahead")
+	require.NoError(t, cmd.Run())
+
+	data := input.Data{Cwd: dir}
+	result, err := modules.GitBranchModule{}.Render(data, cfg)
+	require.NoError(t, err)
+	assert.Contains(t, result, "\u21911") // ↑1
+}
+
+func TestGitBranchModule_SimpleMode_BranchOnly(t *testing.T) {
+	cfg := config.Default()
+	cfg.GitBranch.Mode = "simple"
+	dir := initGitRepo(t)
+
+	// Create a dirty file — should NOT show * in simple mode
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "dirty.txt"), []byte("dirty"), 0644))
+
+	cmd := exec.CommandContext(t.Context(), "git", "-C", dir, "checkout", "-b", "my-branch")
+	require.NoError(t, cmd.Run())
+
+	data := input.Data{Cwd: dir}
+	result, err := modules.GitBranchModule{}.Render(data, cfg)
+	require.NoError(t, err)
+	assert.Contains(t, result, "my-branch")
+	assert.NotContains(t, result, "*")
+}
+
+func TestGitBranchModule_SimpleMode_NonGitDir(t *testing.T) {
+	cfg := config.Default()
+	cfg.GitBranch.Mode = "simple"
+	dir := t.TempDir()
+
+	data := input.Data{Cwd: dir}
+	result, err := modules.GitBranchModule{}.Render(data, cfg)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestGitBranchModule_DetailedMode_NonGitDir(t *testing.T) {
+	cfg := config.Default()
+	dir := t.TempDir()
+
+	data := input.Data{Cwd: dir}
+	result, err := modules.GitBranchModule{}.Render(data, cfg)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}

--- a/internal/modules/porcelain.go
+++ b/internal/modules/porcelain.go
@@ -1,0 +1,54 @@
+package modules
+
+import (
+	"fmt"
+	"strings"
+)
+
+// GitStatus holds parsed output from git status --porcelain=v2 --branch.
+type GitStatus struct {
+	Branch    string
+	Staged    int
+	Modified  int
+	Untracked int
+	Ahead     int
+	Behind    int
+	Conflicts int
+}
+
+// ParsePorcelainV2 parses the output of git status --porcelain=v2 --branch
+// into a GitStatus struct.
+func ParsePorcelainV2(output string) GitStatus {
+	var s GitStatus
+
+	for _, line := range strings.Split(output, "\n") {
+		switch {
+		case strings.HasPrefix(line, "# branch.head "):
+			s.Branch = strings.TrimPrefix(line, "# branch.head ")
+
+		case strings.HasPrefix(line, "# branch.ab "):
+			_, _ = fmt.Sscanf(line, "# branch.ab +%d -%d", &s.Ahead, &s.Behind)
+
+		case strings.HasPrefix(line, "1 ") || strings.HasPrefix(line, "2 "):
+			// Ordinary (1) or rename/copy (2) entry: "1 XY ..." or "2 XY ..."
+			fields := strings.SplitN(line, " ", 3)
+			if len(fields) >= 2 && len(fields[1]) == 2 {
+				xy := fields[1]
+				if xy[0] != '.' {
+					s.Staged++
+				}
+				if xy[1] != '.' {
+					s.Modified++
+				}
+			}
+
+		case strings.HasPrefix(line, "u "):
+			s.Conflicts++
+
+		case strings.HasPrefix(line, "? "):
+			s.Untracked++
+		}
+	}
+
+	return s
+}

--- a/internal/modules/porcelain.go
+++ b/internal/modules/porcelain.go
@@ -19,36 +19,43 @@ type GitStatus struct {
 // ParsePorcelainV2 parses the output of git status --porcelain=v2 --branch
 // into a GitStatus struct.
 func ParsePorcelainV2(output string) GitStatus {
-	var s GitStatus
+	var status GitStatus
 
-	for _, line := range strings.Split(output, "\n") {
+	for line := range strings.SplitSeq(output, "\n") {
 		switch {
 		case strings.HasPrefix(line, "# branch.head "):
-			s.Branch = strings.TrimPrefix(line, "# branch.head ")
+			status.Branch = strings.TrimPrefix(line, "# branch.head ")
 
 		case strings.HasPrefix(line, "# branch.ab "):
-			_, _ = fmt.Sscanf(line, "# branch.ab +%d -%d", &s.Ahead, &s.Behind)
+			_, _ = fmt.Sscanf(line, "# branch.ab +%d -%d", &status.Ahead, &status.Behind)
 
 		case strings.HasPrefix(line, "1 ") || strings.HasPrefix(line, "2 "):
-			// Ordinary (1) or rename/copy (2) entry: "1 XY ..." or "2 XY ..."
-			fields := strings.SplitN(line, " ", 3)
-			if len(fields) >= 2 && len(fields[1]) == 2 {
-				xy := fields[1]
-				if xy[0] != '.' {
-					s.Staged++
-				}
-				if xy[1] != '.' {
-					s.Modified++
-				}
-			}
+			parseChangedEntry(line, &status)
 
 		case strings.HasPrefix(line, "u "):
-			s.Conflicts++
+			status.Conflicts++
 
 		case strings.HasPrefix(line, "? "):
-			s.Untracked++
+			status.Untracked++
 		}
 	}
 
-	return s
+	return status
+}
+
+// parseChangedEntry parses an ordinary (1) or rename/copy (2) porcelain v2 entry.
+func parseChangedEntry(line string, status *GitStatus) {
+	// "1 XY sub ..." or "2 XY sub ..." — XY is at field index 1.
+	statusXY, _, found := strings.Cut(line[2:], " ")
+	if !found || len(statusXY) != 2 {
+		return
+	}
+
+	if statusXY[0] != '.' {
+		status.Staged++
+	}
+
+	if statusXY[1] != '.' {
+		status.Modified++
+	}
 }

--- a/internal/modules/porcelain_test.go
+++ b/internal/modules/porcelain_test.go
@@ -1,0 +1,124 @@
+package modules_test
+
+import (
+	"testing"
+
+	"github.com/felipeelias/claude-statusline/internal/modules"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParsePorcelainV2_CleanBranch(t *testing.T) {
+	output := "# branch.oid abc123\n# branch.head main\n"
+	s := modules.ParsePorcelainV2(output)
+
+	assert.Equal(t, "main", s.Branch)
+	assert.Equal(t, 0, s.Staged)
+	assert.Equal(t, 0, s.Modified)
+	assert.Equal(t, 0, s.Untracked)
+	assert.Equal(t, 0, s.Ahead)
+	assert.Equal(t, 0, s.Behind)
+	assert.Equal(t, 0, s.Conflicts)
+	assert.Equal(t, 0, s.Staged+s.Modified+s.Untracked+s.Conflicts)
+}
+
+func TestParsePorcelainV2_StagedFiles(t *testing.T) {
+	output := "# branch.oid abc123\n# branch.head main\n1 A. N... 000000 100644 100644 0000 abcd file.txt\n"
+	s := modules.ParsePorcelainV2(output)
+
+	assert.Equal(t, 1, s.Staged)
+	assert.Equal(t, 0, s.Modified)
+}
+
+func TestParsePorcelainV2_ModifiedFiles(t *testing.T) {
+	output := "# branch.oid abc123\n# branch.head main\n1 .M N... 100644 100644 100644 abcd abcd file.txt\n"
+	s := modules.ParsePorcelainV2(output)
+
+	assert.Equal(t, 0, s.Staged)
+	assert.Equal(t, 1, s.Modified)
+}
+
+func TestParsePorcelainV2_StagedAndModified(t *testing.T) {
+	output := "# branch.oid abc123\n# branch.head main\n1 MM N... 100644 100644 100644 abcd abcd file.txt\n"
+	s := modules.ParsePorcelainV2(output)
+
+	assert.Equal(t, 1, s.Staged)
+	assert.Equal(t, 1, s.Modified)
+}
+
+func TestParsePorcelainV2_UntrackedFiles(t *testing.T) {
+	output := "# branch.oid abc123\n# branch.head main\n? untracked.txt\n"
+	s := modules.ParsePorcelainV2(output)
+
+	assert.Equal(t, 1, s.Untracked)
+}
+
+func TestParsePorcelainV2_AheadBehind(t *testing.T) {
+	output := "# branch.oid abc123\n# branch.head main\n# branch.upstream origin/main\n# branch.ab +3 -1\n"
+	s := modules.ParsePorcelainV2(output)
+
+	assert.Equal(t, 3, s.Ahead)
+	assert.Equal(t, 1, s.Behind)
+}
+
+func TestParsePorcelainV2_NoUpstream(t *testing.T) {
+	output := "# branch.oid abc123\n# branch.head feature\n"
+	s := modules.ParsePorcelainV2(output)
+
+	assert.Equal(t, "feature", s.Branch)
+	assert.Equal(t, 0, s.Ahead)
+	assert.Equal(t, 0, s.Behind)
+}
+
+func TestParsePorcelainV2_DetachedHead(t *testing.T) {
+	output := "# branch.oid abc123def456\n# branch.head (detached)\n"
+	s := modules.ParsePorcelainV2(output)
+
+	assert.Equal(t, "(detached)", s.Branch)
+}
+
+func TestParsePorcelainV2_Conflicts(t *testing.T) {
+	output := "# branch.oid abc123\n# branch.head main\nu UU N... 100644 100644 100644 100644 abcd efgh ijkl conflict.txt\n"
+	s := modules.ParsePorcelainV2(output)
+
+	assert.Equal(t, 1, s.Conflicts)
+}
+
+func TestParsePorcelainV2_RenamedFile(t *testing.T) {
+	output := "# branch.oid abc123\n# branch.head main\n2 R. N... 100644 100644 100644 abcd abcd R100 new.txt\told.txt\n"
+	s := modules.ParsePorcelainV2(output)
+
+	assert.Equal(t, 1, s.Staged)
+	assert.Equal(t, 0, s.Modified)
+}
+
+func TestParsePorcelainV2_MixedState(t *testing.T) {
+	output := "# branch.oid abc123\n# branch.head main\n# branch.upstream origin/main\n# branch.ab +1 -0\n" +
+		"1 A. N... 000000 100644 100644 0000 abcd staged.txt\n" +
+		"1 .M N... 100644 100644 100644 abcd abcd modified.txt\n" +
+		"? untracked.txt\n" +
+		"u UU N... 100644 100644 100644 100644 abcd efgh ijkl conflict.txt\n"
+	s := modules.ParsePorcelainV2(output)
+
+	assert.Equal(t, "main", s.Branch)
+	assert.Equal(t, 1, s.Staged)
+	assert.Equal(t, 1, s.Modified)
+	assert.Equal(t, 1, s.Untracked)
+	assert.Equal(t, 1, s.Conflicts)
+	assert.Equal(t, 1, s.Ahead)
+	assert.Equal(t, 0, s.Behind)
+}
+
+func TestParsePorcelainV2_EmptyOutput(t *testing.T) {
+	s := modules.ParsePorcelainV2("")
+
+	assert.Equal(t, "", s.Branch)
+	assert.Equal(t, 0, s.Staged+s.Modified+s.Untracked+s.Conflicts)
+}
+
+func TestParsePorcelainV2_InitialCommit(t *testing.T) {
+	output := "# branch.oid (initial)\n# branch.head main\n? README.md\n"
+	s := modules.ParsePorcelainV2(output)
+
+	assert.Equal(t, "main", s.Branch)
+	assert.Equal(t, 1, s.Untracked)
+}

--- a/internal/modules/porcelain_test.go
+++ b/internal/modules/porcelain_test.go
@@ -9,116 +9,122 @@ import (
 
 func TestParsePorcelainV2_CleanBranch(t *testing.T) {
 	output := "# branch.oid abc123\n# branch.head main\n"
-	s := modules.ParsePorcelainV2(output)
+	status := modules.ParsePorcelainV2(output)
 
-	assert.Equal(t, "main", s.Branch)
-	assert.Equal(t, 0, s.Staged)
-	assert.Equal(t, 0, s.Modified)
-	assert.Equal(t, 0, s.Untracked)
-	assert.Equal(t, 0, s.Ahead)
-	assert.Equal(t, 0, s.Behind)
-	assert.Equal(t, 0, s.Conflicts)
-	assert.Equal(t, 0, s.Staged+s.Modified+s.Untracked+s.Conflicts)
+	assert.Equal(t, "main", status.Branch)
+	assert.Equal(t, 0, status.Staged)
+	assert.Equal(t, 0, status.Modified)
+	assert.Equal(t, 0, status.Untracked)
+	assert.Equal(t, 0, status.Ahead)
+	assert.Equal(t, 0, status.Behind)
+	assert.Equal(t, 0, status.Conflicts)
 }
 
 func TestParsePorcelainV2_StagedFiles(t *testing.T) {
-	output := "# branch.oid abc123\n# branch.head main\n1 A. N... 000000 100644 100644 0000 abcd file.txt\n"
-	s := modules.ParsePorcelainV2(output)
+	output := "# branch.oid abc123\n# branch.head main\n" +
+		"1 A. N... 000000 100644 100644 0000 abcd file.txt\n"
+	status := modules.ParsePorcelainV2(output)
 
-	assert.Equal(t, 1, s.Staged)
-	assert.Equal(t, 0, s.Modified)
+	assert.Equal(t, 1, status.Staged)
+	assert.Equal(t, 0, status.Modified)
 }
 
 func TestParsePorcelainV2_ModifiedFiles(t *testing.T) {
-	output := "# branch.oid abc123\n# branch.head main\n1 .M N... 100644 100644 100644 abcd abcd file.txt\n"
-	s := modules.ParsePorcelainV2(output)
+	output := "# branch.oid abc123\n# branch.head main\n" +
+		"1 .M N... 100644 100644 100644 abcd1234 efgh5678 file.txt\n"
+	status := modules.ParsePorcelainV2(output)
 
-	assert.Equal(t, 0, s.Staged)
-	assert.Equal(t, 1, s.Modified)
+	assert.Equal(t, 0, status.Staged)
+	assert.Equal(t, 1, status.Modified)
 }
 
 func TestParsePorcelainV2_StagedAndModified(t *testing.T) {
-	output := "# branch.oid abc123\n# branch.head main\n1 MM N... 100644 100644 100644 abcd abcd file.txt\n"
-	s := modules.ParsePorcelainV2(output)
+	output := "# branch.oid abc123\n# branch.head main\n" +
+		"1 MM N... 100644 100644 100644 abcd1234 efgh5678 file.txt\n"
+	status := modules.ParsePorcelainV2(output)
 
-	assert.Equal(t, 1, s.Staged)
-	assert.Equal(t, 1, s.Modified)
+	assert.Equal(t, 1, status.Staged)
+	assert.Equal(t, 1, status.Modified)
 }
 
 func TestParsePorcelainV2_UntrackedFiles(t *testing.T) {
 	output := "# branch.oid abc123\n# branch.head main\n? untracked.txt\n"
-	s := modules.ParsePorcelainV2(output)
+	status := modules.ParsePorcelainV2(output)
 
-	assert.Equal(t, 1, s.Untracked)
+	assert.Equal(t, 1, status.Untracked)
 }
 
 func TestParsePorcelainV2_AheadBehind(t *testing.T) {
-	output := "# branch.oid abc123\n# branch.head main\n# branch.upstream origin/main\n# branch.ab +3 -1\n"
-	s := modules.ParsePorcelainV2(output)
+	output := "# branch.oid abc123\n# branch.head main\n" +
+		"# branch.upstream origin/main\n# branch.ab +3 -1\n"
+	status := modules.ParsePorcelainV2(output)
 
-	assert.Equal(t, 3, s.Ahead)
-	assert.Equal(t, 1, s.Behind)
+	assert.Equal(t, 3, status.Ahead)
+	assert.Equal(t, 1, status.Behind)
 }
 
 func TestParsePorcelainV2_NoUpstream(t *testing.T) {
 	output := "# branch.oid abc123\n# branch.head feature\n"
-	s := modules.ParsePorcelainV2(output)
+	status := modules.ParsePorcelainV2(output)
 
-	assert.Equal(t, "feature", s.Branch)
-	assert.Equal(t, 0, s.Ahead)
-	assert.Equal(t, 0, s.Behind)
+	assert.Equal(t, "feature", status.Branch)
+	assert.Equal(t, 0, status.Ahead)
+	assert.Equal(t, 0, status.Behind)
 }
 
 func TestParsePorcelainV2_DetachedHead(t *testing.T) {
 	output := "# branch.oid abc123def456\n# branch.head (detached)\n"
-	s := modules.ParsePorcelainV2(output)
+	status := modules.ParsePorcelainV2(output)
 
-	assert.Equal(t, "(detached)", s.Branch)
+	assert.Equal(t, "(detached)", status.Branch)
 }
 
 func TestParsePorcelainV2_Conflicts(t *testing.T) {
-	output := "# branch.oid abc123\n# branch.head main\nu UU N... 100644 100644 100644 100644 abcd efgh ijkl conflict.txt\n"
-	s := modules.ParsePorcelainV2(output)
+	output := "# branch.oid abc123\n# branch.head main\n" +
+		"u UU N... 100644 100644 100644 100644 abcd efgh ijkl conflict.txt\n"
+	status := modules.ParsePorcelainV2(output)
 
-	assert.Equal(t, 1, s.Conflicts)
+	assert.Equal(t, 1, status.Conflicts)
 }
 
 func TestParsePorcelainV2_RenamedFile(t *testing.T) {
-	output := "# branch.oid abc123\n# branch.head main\n2 R. N... 100644 100644 100644 abcd abcd R100 new.txt\told.txt\n"
-	s := modules.ParsePorcelainV2(output)
+	output := "# branch.oid abc123\n# branch.head main\n" +
+		"2 R. N... 100644 100644 100644 abcd1234 efgh5678 R100 new.txt\told.txt\n"
+	status := modules.ParsePorcelainV2(output)
 
-	assert.Equal(t, 1, s.Staged)
-	assert.Equal(t, 0, s.Modified)
+	assert.Equal(t, 1, status.Staged)
+	assert.Equal(t, 0, status.Modified)
 }
 
 func TestParsePorcelainV2_MixedState(t *testing.T) {
-	output := "# branch.oid abc123\n# branch.head main\n# branch.upstream origin/main\n# branch.ab +1 -0\n" +
+	output := "# branch.oid abc123\n# branch.head main\n" +
+		"# branch.upstream origin/main\n# branch.ab +1 -0\n" +
 		"1 A. N... 000000 100644 100644 0000 abcd staged.txt\n" +
-		"1 .M N... 100644 100644 100644 abcd abcd modified.txt\n" +
+		"1 .M N... 100644 100644 100644 abcd1234 efgh5678 modified.txt\n" +
 		"? untracked.txt\n" +
 		"u UU N... 100644 100644 100644 100644 abcd efgh ijkl conflict.txt\n"
-	s := modules.ParsePorcelainV2(output)
+	status := modules.ParsePorcelainV2(output)
 
-	assert.Equal(t, "main", s.Branch)
-	assert.Equal(t, 1, s.Staged)
-	assert.Equal(t, 1, s.Modified)
-	assert.Equal(t, 1, s.Untracked)
-	assert.Equal(t, 1, s.Conflicts)
-	assert.Equal(t, 1, s.Ahead)
-	assert.Equal(t, 0, s.Behind)
+	assert.Equal(t, "main", status.Branch)
+	assert.Equal(t, 1, status.Staged)
+	assert.Equal(t, 1, status.Modified)
+	assert.Equal(t, 1, status.Untracked)
+	assert.Equal(t, 1, status.Conflicts)
+	assert.Equal(t, 1, status.Ahead)
+	assert.Equal(t, 0, status.Behind)
 }
 
 func TestParsePorcelainV2_EmptyOutput(t *testing.T) {
-	s := modules.ParsePorcelainV2("")
+	status := modules.ParsePorcelainV2("")
 
-	assert.Equal(t, "", s.Branch)
-	assert.Equal(t, 0, s.Staged+s.Modified+s.Untracked+s.Conflicts)
+	assert.Empty(t, status.Branch)
+	assert.Equal(t, 0, status.Staged+status.Modified+status.Untracked+status.Conflicts)
 }
 
 func TestParsePorcelainV2_InitialCommit(t *testing.T) {
 	output := "# branch.oid (initial)\n# branch.head main\n? README.md\n"
-	s := modules.ParsePorcelainV2(output)
+	status := modules.ParsePorcelainV2(output)
 
-	assert.Equal(t, "main", s.Branch)
-	assert.Equal(t, 1, s.Untracked)
+	assert.Equal(t, "main", status.Branch)
+	assert.Equal(t, 1, status.Untracked)
 }


### PR DESCRIPTION
## Summary

- Add staged/modified/untracked file counts, ahead/behind remote tracking, dirty/clean flags, and merge conflict count to the `git_branch` module
- Parse all data from `git status --porcelain=v2 --branch` in a single command
- Add `mode` config field: `"detailed"` (default) runs porcelain v2, `"simple"` uses fast `git rev-parse` only (for large repos)
- Minimal preset uses `mode = "simple"` since its format only shows branch name

## New template fields

| Field | Type | Description |
|---|---|---|
| `{{.Staged}}` | int | Staged file count |
| `{{.Modified}}` | int | Modified (unstaged) file count |
| `{{.Untracked}}` | int | Untracked file count |
| `{{.Ahead}}` | int | Commits ahead of upstream |
| `{{.Behind}}` | int | Commits behind upstream |
| `{{.Conflicts}}` | int | Merge conflict count |
| `{{.IsDirty}}` | bool | Any uncommitted changes |
| `{{.IsClean}}` | bool | No uncommitted changes |

## Default format

```
 branch_name *  ↑1 ↓2
```

Shows `*` when dirty, `↑N`/`↓N` for ahead/behind. Clean repos show branch name only.

## Config

```toml
[git_branch]
mode = "detailed"  # or "simple" for fast branch-name-only mode
```

## Test plan

- [x] Parser unit tests (13 cases) — clean, staged, modified, untracked, ahead/behind, detached HEAD, conflicts, renames, mixed state, empty, initial commit
- [x] Integration tests (7 cases) — detailed clean/dirty/staged/ahead, simple mode branch-only, non-git dirs
- [x] All existing tests pass unchanged
- [x] `go vet` clean
- [x] Visual verification with `test` and `themes` commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Git branch display adds configurable modes: "simple" (name-only) and "detailed" (dirty marker, ahead/behind glyphs and counts). Preset themes now set appropriate defaults.

* **Bug Fixes / Improvements**
  * More accurate detailed status detection by parsing modern git porcelain output and handling timeouts for git calls.

* **Tests**
  * Added comprehensive tests for both modes and many repository states (clean, dirty, staged, ahead/behind, conflicts).

* **Documentation**
  * Updated sample configuration and roadmap to document the new mode, template fields, and timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->