### PR TITLE
feat: add burn rate and API duration to cost module

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -50,30 +50,6 @@ The module name stays `git_branch` and config key stays `[git_branch]` for backw
 
 ---
 
-### 2. Burn rate (cost per hour)
-
-Add `{{.BurnRate}}` and `{{.APIDurationMs}}` fields to the cost module. Burn rate shows dollars-per-hour based on session duration and total cost. API duration comes from the new `cost.total_api_duration_ms` field in the JSON payload.
-
-**New template fields on cost module:**
-
-| Field               | Type    | Description                                                |
-| ------------------- | ------- | ---------------------------------------------------------- |
-| `{{.BurnRate}}`     | float64 | Cost per hour (TotalCostUSD / (TotalDurationMs / 3600000)) |
-| `{{.APIDurationMs}}`| int     | Total time spent waiting for API responses (ms)            |
-
-If duration is zero, `BurnRate` is `0`.
-
-**Example config:**
-
-```toml
-[cost]
-format = '${{printf "%.2f" .TotalCostUSD}} ({{printf "%.2f" .BurnRate}}/hr)'
-```
-
-**Default format:** Keep the current default (`$X.XX`) unchanged. The burn rate is opt-in via format customization.
-
----
-
 ### 3. Context bar display styles
 
 The context module currently renders a progress bar using configurable `bar_fill` and `bar_empty` characters. Add a `bar_style` config field that selects from named presets, making it easy to switch visual styles without manually setting fill/empty characters.

--- a/internal/modules/cost.go
+++ b/internal/modules/cost.go
@@ -5,6 +5,8 @@ import (
 	"github.com/felipeelias/claude-statusline/internal/input"
 )
 
+const msPerHour = 3_600_000
+
 // CostModule renders the session cost with threshold-based styling.
 type CostModule struct{}
 
@@ -13,7 +15,21 @@ func (CostModule) Name() string { return "cost" }
 func (CostModule) Render(data input.Data, cfg config.Config) (string, error) {
 	cost := data.Cost.TotalCostUSD
 
-	templateData := struct{ TotalCostUSD float64 }{TotalCostUSD: cost}
+	var burnRate float64
+	if data.Cost.TotalDurationMs > 0 {
+		hours := float64(data.Cost.TotalDurationMs) / msPerHour
+		burnRate = cost / hours
+	}
+
+	templateData := struct {
+		TotalCostUSD   float64
+		BurnRate       float64
+		APIDurationMs  int
+	}{
+		TotalCostUSD:  cost,
+		BurnRate:      burnRate,
+		APIDurationMs: data.Cost.TotalAPIDurationMs,
+	}
 
 	result, err := renderTemplate("cost", cfg.Cost.Format, templateData)
 	if err != nil {

--- a/internal/modules/cost_test.go
+++ b/internal/modules/cost_test.go
@@ -70,4 +70,50 @@ func TestCostModule_Render(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, result, "\033[32m")
 	})
+
+	t.Run("burn rate template field", func(t *testing.T) {
+		burnCfg := cfg
+		burnCfg.Cost.Format = `${{printf "%.2f" .TotalCostUSD}} ({{printf "%.2f" .BurnRate}}/hr)`
+
+		data := input.Data{
+			Cost: input.Cost{
+				TotalCostUSD:    1.00,
+				TotalDurationMs: 1_800_000, // 30 minutes
+			},
+		}
+
+		result, err := modules.CostModule{}.Render(data, burnCfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "$1.00")
+		assert.Contains(t, result, "2.00/hr")
+	})
+
+	t.Run("burn rate zero when duration is zero", func(t *testing.T) {
+		burnCfg := cfg
+		burnCfg.Cost.Format = `{{printf "%.2f" .BurnRate}}/hr`
+
+		data := input.Data{
+			Cost: input.Cost{
+				TotalCostUSD:    1.00,
+				TotalDurationMs: 0,
+			},
+		}
+
+		result, err := modules.CostModule{}.Render(data, burnCfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "0.00/hr")
+	})
+
+	t.Run("api duration template field", func(t *testing.T) {
+		apiCfg := cfg
+		apiCfg.Cost.Format = `{{.APIDurationMs}}ms`
+
+		data := input.Data{
+			Cost: input.Cost{TotalAPIDurationMs: 2300},
+		}
+
+		result, err := modules.CostModule{}.Render(data, apiCfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "2300ms")
+	})
 }


### PR DESCRIPTION
## Summary

Add `{{.BurnRate}}` and `{{.APIDurationMs}}` template fields to the cost module.

## Why

Users tracking session costs want to see spend velocity, not just the total. Burn rate (dollars per hour) makes it easy to gauge whether a session is expensive relative to its duration.

## What

- Add `BurnRate` (cost/hour) and `APIDurationMs` to cost module template data
- `BurnRate` is 0 when session duration is 0
- Default format unchanged; burn rate is opt-in via custom format
- Remove completed section from roadmap