### PR TITLE
feat: add bar_style presets for progress bars

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -50,36 +50,7 @@ The module name stays `git_branch` and config key stays `[git_branch]` for backw
 
 ---
 
-### 3. Context bar display styles
-
-The context module currently renders a progress bar using configurable `bar_fill` and `bar_empty` characters. Add a `bar_style` config field that selects from named presets, making it easy to switch visual styles without manually setting fill/empty characters.
-
-**New config field:**
-
-```toml
-[context]
-bar_style = "blocks"
-```
-
-**Built-in bar styles:**
-
-| Name      | Fill | Empty | Example (60%)             |
-| --------- | ---- | ----- | ------------------------- |
-| `classic` | `█`  | `░`   | `███░░` (current default) |
-| `blocks`  | `█`  | `▒`   | `███▒▒`                   |
-| `dots`    | `⣿`  | `⣀`   | `⣿⣿⣿⣀⣀`                   |
-| `line`    | `━`  | `─`   | `━━━──`                   |
-| `squares` | `◼`  | `◻`   | `◼◼◼◻◻`                   |
-
-**Behavior:**
-
-- When `bar_style` is set, it overrides `bar_fill` and `bar_empty`.
-- When `bar_fill` or `bar_empty` are explicitly set alongside `bar_style`, the explicit values win (user overrides take priority).
-- Default: no `bar_style` set, uses `bar_fill`/`bar_empty` directly (preserves current behavior).
-
----
-
-### 4. Directory display modes
+### 3. Directory display modes
 
 The directory module currently does tilde substitution and first-character truncation of path segments beyond `truncation_length`. Add a `display_mode` config field that controls the truncation strategy.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,7 +110,6 @@ const (
 
 // Default returns a Config with hardcoded default values.
 //
-//nolint:funlen // single-struct initializer reads best as one block
 func Default() Config {
 	return Config{
 		Preset: "default",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,6 +57,7 @@ type ContextConfig struct {
 	Style      string      `toml:"style"`
 	Disabled   bool        `toml:"disabled"`
 	BarWidth   int         `toml:"bar_width"`
+	BarStyle   string      `toml:"bar_style"`
 	BarFill    string      `toml:"bar_fill"`
 	BarEmpty   string      `toml:"bar_empty"`
 	Thresholds []Threshold `toml:"thresholds"`
@@ -91,6 +92,7 @@ type UsageConfig struct {
 	Style      string      `toml:"style"`
 	Disabled   bool        `toml:"disabled"`
 	BarWidth   int         `toml:"bar_width"`
+	BarStyle   string      `toml:"bar_style"`
 	BarFill    string      `toml:"bar_fill"`
 	BarEmpty   string      `toml:"bar_empty"`
 	Thresholds []Threshold `toml:"thresholds"`
@@ -98,9 +100,7 @@ type UsageConfig struct {
 
 const (
 	defaultTruncationLength = 3
-	defaultBarWidth         = 5
-	defaultBarFill          = "\u2588" // █
-	defaultBarEmpty         = "\u2591" // ░
+	defaultBarWidth = 5
 	costWarnThreshold       = 5.0
 	ctxWarnThreshold        = 50
 	ctxHighThreshold        = 90
@@ -136,8 +136,6 @@ func Default() Config {
 			Format:   `{{.Bar}} {{printf "%.0f" .UsedPct}}%`,
 			Style:    "green",
 			BarWidth: defaultBarWidth,
-			BarFill:  defaultBarFill,
-			BarEmpty: defaultBarEmpty,
 			Thresholds: []Threshold{
 				{Above: ctxWarnThreshold, Style: "yellow"},
 				{Above: ctxHighThreshold, Style: "red"},
@@ -168,8 +166,6 @@ func Default() Config {
 			Style:    "green",
 			Disabled: true,
 			BarWidth: defaultBarWidth,
-			BarFill:  defaultBarFill,
-			BarEmpty: defaultBarEmpty,
 			Thresholds: []Threshold{
 				{Above: usageWarnThreshold, Style: "yellow"},
 				{Above: usageHighThreshold, Style: "red"},
@@ -274,8 +270,9 @@ format = "$directory | $git_branch | $model | $cost | $context"
 # format = '{{.Bar}} {{printf "%.0f" .UsedPct}}%'
 # style = "green"
 # bar_width = 5
-# bar_fill = "█"
-# bar_empty = "░"
+# bar_style = ""  # "classic", "blocks", "dots", "line", "squares"
+# bar_fill = "█"   # overrides bar_style fill character
+# bar_empty = "░"  # overrides bar_style empty character
 # thresholds = [
 #   { above = 50, style = "yellow" },
 #   { above = 90, style = "red" },

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -269,9 +269,9 @@ format = "$directory | $git_branch | $model | $cost | $context"
 # format = '{{.Bar}} {{printf "%.0f" .UsedPct}}%'
 # style = "green"
 # bar_width = 5
-# bar_style = ""  # "classic", "blocks", "dots", "line", "squares"
-# bar_fill = "█"   # overrides bar_style fill character
-# bar_empty = "░"  # overrides bar_style empty character
+# bar_style = "classic"  # "classic", "blocks", "dots", "line", "squares"
+# bar_fill = "█"         # overrides bar_style fill character
+# bar_empty = "░"        # overrides bar_style empty character
 # thresholds = [
 #   { above = 50, style = "yellow" },
 #   { above = 90, style = "red" },
@@ -302,6 +302,9 @@ format = "$directory | $git_branch | $model | $cost | $context"
 # format = '{{.BlockBar}} {{printf "%.0f" .BlockPct}}% W:{{printf "%.0f" .WeeklyPct}}%'
 # style = "green"
 # bar_width = 5
+# bar_style = "classic"  # "classic", "blocks", "dots", "line", "squares"
+# bar_fill = "█"         # overrides bar_style fill character
+# bar_empty = "░"        # overrides bar_style empty character
 # thresholds = [
 #   { above = 75, style = "yellow" },
 #   { above = 90, style = "red" },

--- a/internal/config/themes.go
+++ b/internal/config/themes.go
@@ -127,7 +127,7 @@ func powerlineConfig(preset string, format string, segFg string, colors [5]strin
 		},
 		Context: ContextConfig{
 			Format: ` {{.Bar}} {{printf "%.0f" .UsedPct}}% `, Style: segStyle(segFg, colors[4]),
-			BarWidth: defaultBarWidth, BarFill: defaultBarFill, BarEmpty: defaultBarEmpty,
+			BarWidth: defaultBarWidth,
 			Thresholds: []Threshold{
 				{Above: ctxWarnThreshold, Style: segStyle(thresholds.warn, colors[4])},
 				{Above: ctxHighThreshold, Style: segStyle(thresholds.high, colors[4])},
@@ -146,8 +146,6 @@ func powerlineConfig(preset string, format string, segFg string, colors [5]strin
 			Style:    segStyle(segFg, colors[4]),
 			Disabled: true,
 			BarWidth: defaultBarWidth,
-			BarFill:  defaultBarFill,
-			BarEmpty: defaultBarEmpty,
 			Thresholds: []Threshold{
 				{Above: usageWarnThreshold, Style: segStyle(thresholds.warn, colors[4])},
 				{Above: usageHighThreshold, Style: segStyle(thresholds.high, colors[4])},

--- a/internal/modules/context.go
+++ b/internal/modules/context.go
@@ -13,7 +13,8 @@ func (ContextModule) Name() string { return "context" }
 func (ContextModule) Render(data input.Data, cfg config.Config) (string, error) {
 	pct := data.ContextWindow.UsedPercentage
 
-	bar := buildBar(pct, cfg.Context.BarWidth, cfg.Context.BarFill, cfg.Context.BarEmpty)
+	fill, empty := resolveBarChars(cfg.Context.BarStyle, cfg.Context.BarFill, cfg.Context.BarEmpty)
+	bar := buildBar(pct, cfg.Context.BarWidth, fill, empty)
 
 	templateData := struct {
 		Bar     string

--- a/internal/modules/context_test.go
+++ b/internal/modules/context_test.go
@@ -105,4 +105,50 @@ func TestContextModule_Render(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, result, "\033[32m")
 	})
+
+	t.Run("bar_style dots", func(t *testing.T) {
+		dotsCfg := cfg
+		dotsCfg.Context.BarStyle = "dots"
+
+		data := input.Data{
+			ContextWindow: input.ContextWindow{
+				UsedPercentage: 60.0,
+			},
+		}
+
+		result, err := modules.ContextModule{}.Render(data, dotsCfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "\u28ff\u28ff\u28ff\u28c0\u28c0")
+	})
+
+	t.Run("bar_style line", func(t *testing.T) {
+		lineCfg := cfg
+		lineCfg.Context.BarStyle = "line"
+
+		data := input.Data{
+			ContextWindow: input.ContextWindow{
+				UsedPercentage: 40.0,
+			},
+		}
+
+		result, err := modules.ContextModule{}.Render(data, lineCfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "\u2501\u2501\u2500\u2500\u2500")
+	})
+
+	t.Run("explicit bar_fill overrides bar_style", func(t *testing.T) {
+		overrideCfg := cfg
+		overrideCfg.Context.BarStyle = "dots"
+		overrideCfg.Context.BarFill = "#"
+
+		data := input.Data{
+			ContextWindow: input.ContextWindow{
+				UsedPercentage: 60.0,
+			},
+		}
+
+		result, err := modules.ContextModule{}.Render(data, overrideCfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "###\u28c0\u28c0")
+	})
 }

--- a/internal/modules/context_test.go
+++ b/internal/modules/context_test.go
@@ -106,49 +106,4 @@ func TestContextModule_Render(t *testing.T) {
 		assert.Contains(t, result, "\033[32m")
 	})
 
-	t.Run("bar_style dots", func(t *testing.T) {
-		dotsCfg := cfg
-		dotsCfg.Context.BarStyle = "dots"
-
-		data := input.Data{
-			ContextWindow: input.ContextWindow{
-				UsedPercentage: 60.0,
-			},
-		}
-
-		result, err := modules.ContextModule{}.Render(data, dotsCfg)
-		require.NoError(t, err)
-		assert.Contains(t, result, "\u28ff\u28ff\u28ff\u28c0\u28c0")
-	})
-
-	t.Run("bar_style line", func(t *testing.T) {
-		lineCfg := cfg
-		lineCfg.Context.BarStyle = "line"
-
-		data := input.Data{
-			ContextWindow: input.ContextWindow{
-				UsedPercentage: 40.0,
-			},
-		}
-
-		result, err := modules.ContextModule{}.Render(data, lineCfg)
-		require.NoError(t, err)
-		assert.Contains(t, result, "\u2501\u2501\u2500\u2500\u2500")
-	})
-
-	t.Run("explicit bar_fill overrides bar_style", func(t *testing.T) {
-		overrideCfg := cfg
-		overrideCfg.Context.BarStyle = "dots"
-		overrideCfg.Context.BarFill = "#"
-
-		data := input.Data{
-			ContextWindow: input.ContextWindow{
-				UsedPercentage: 60.0,
-			},
-		}
-
-		result, err := modules.ContextModule{}.Render(data, overrideCfg)
-		require.NoError(t, err)
-		assert.Contains(t, result, "###\u28c0\u28c0")
-	})
 }

--- a/internal/modules/context_test.go
+++ b/internal/modules/context_test.go
@@ -105,5 +105,4 @@ func TestContextModule_Render(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, result, "\033[32m")
 	})
-
 }

--- a/internal/modules/helpers.go
+++ b/internal/modules/helpers.go
@@ -51,8 +51,9 @@ var barStyles = map[string]barPreset{
 // resolveBarChars determines the fill and empty characters for a progress bar.
 // Priority: explicit bar_fill/bar_empty > bar_style preset > classic defaults.
 func resolveBarChars(barStyle, barFill, barEmpty string) (string, string) {
-	fill := "\u2588" // █ classic default
-	empty := "\u2591" // ░ classic default
+	classic := barStyles["classic"]
+	fill := classic.Fill
+	empty := classic.Empty
 
 	if preset, ok := barStyles[barStyle]; ok {
 		fill = preset.Fill

--- a/internal/modules/helpers.go
+++ b/internal/modules/helpers.go
@@ -33,6 +33,43 @@ func wrapStyle(text, styleStr string) string {
 
 const pctMax = 100
 
+// barPreset defines a named pair of fill/empty characters for progress bars.
+type barPreset struct {
+	Fill  string
+	Empty string
+}
+
+// barStyles maps bar_style names to their fill/empty character presets.
+var barStyles = map[string]barPreset{
+	"classic": {Fill: "\u2588", Empty: "\u2591"}, // █ ░
+	"blocks":  {Fill: "\u2588", Empty: "\u2592"}, // █ ▒
+	"dots":    {Fill: "\u28ff", Empty: "\u28c0"}, // ⣿ ⣀
+	"line":    {Fill: "\u2501", Empty: "\u2500"}, // ━ ─
+	"squares": {Fill: "\u25fc", Empty: "\u25fb"}, // ◼ ◻
+}
+
+// resolveBarChars determines the fill and empty characters for a progress bar.
+// Priority: explicit bar_fill/bar_empty > bar_style preset > classic defaults.
+func resolveBarChars(barStyle, barFill, barEmpty string) (string, string) {
+	fill := "\u2588" // █ classic default
+	empty := "\u2591" // ░ classic default
+
+	if preset, ok := barStyles[barStyle]; ok {
+		fill = preset.Fill
+		empty = preset.Empty
+	}
+
+	if barFill != "" {
+		fill = barFill
+	}
+
+	if barEmpty != "" {
+		empty = barEmpty
+	}
+
+	return fill, empty
+}
+
 // buildBar creates a progress bar string from a percentage value.
 func buildBar(pct float64, width int, fill, empty string) string {
 	filled := min(max(int(pct/pctMax*float64(width)), 0), width)

--- a/internal/modules/helpers_test.go
+++ b/internal/modules/helpers_test.go
@@ -104,3 +104,39 @@ func TestResolveBarChars_ViaContextModule(t *testing.T) {
 		assert.Contains(t, result, "###--")
 	})
 }
+
+func TestResolveBarChars_ViaUsageModule(t *testing.T) {
+	baseCfg := config.Default()
+	baseCfg.Usage.Format = "{{.BlockBar}}"
+	baseCfg.Usage.BarWidth = 5
+
+	data := input.Data{
+		RateLimits: &input.RateLimits{
+			FiveHour: input.RateLimitWindow{UsedPercentage: 60.0},
+			SevenDay: input.RateLimitWindow{UsedPercentage: 10.0},
+		},
+	}
+
+	t.Run("no bar_style uses classic defaults", func(t *testing.T) {
+		result, err := modules.UsageModule{}.Render(data, baseCfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "\u2588\u2588\u2588\u2591\u2591")
+	})
+
+	t.Run("bar_style dots", func(t *testing.T) {
+		cfg := baseCfg
+		cfg.Usage.BarStyle = barStyleDots
+		result, err := modules.UsageModule{}.Render(data, cfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "\u28ff\u28ff\u28ff\u28c0\u28c0")
+	})
+
+	t.Run("explicit bar_fill overrides bar_style", func(t *testing.T) {
+		cfg := baseCfg
+		cfg.Usage.BarStyle = barStyleDots
+		cfg.Usage.BarFill = "#"
+		result, err := modules.UsageModule{}.Render(data, cfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "###\u28c0\u28c0")
+	})
+}

--- a/internal/modules/helpers_test.go
+++ b/internal/modules/helpers_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const barStyleDots = "dots"
+
 func TestResolveBarChars_ViaContextModule(t *testing.T) {
 	baseCfg := config.Default()
 	baseCfg.Context.Format = "{{.Bar}}"
@@ -27,7 +29,7 @@ func TestResolveBarChars_ViaContextModule(t *testing.T) {
 
 	t.Run("bar_style dots", func(t *testing.T) {
 		cfg := baseCfg
-		cfg.Context.BarStyle = "dots"
+		cfg.Context.BarStyle = barStyleDots
 		result, err := modules.ContextModule{}.Render(data, cfg)
 		require.NoError(t, err)
 		assert.Contains(t, result, "\u28ff\u28ff\u28ff\u28c0\u28c0")
@@ -59,7 +61,7 @@ func TestResolveBarChars_ViaContextModule(t *testing.T) {
 
 	t.Run("explicit bar_fill overrides bar_style", func(t *testing.T) {
 		cfg := baseCfg
-		cfg.Context.BarStyle = "dots"
+		cfg.Context.BarStyle = barStyleDots
 		cfg.Context.BarFill = "#"
 		result, err := modules.ContextModule{}.Render(data, cfg)
 		require.NoError(t, err)
@@ -68,7 +70,7 @@ func TestResolveBarChars_ViaContextModule(t *testing.T) {
 
 	t.Run("explicit bar_empty overrides bar_style", func(t *testing.T) {
 		cfg := baseCfg
-		cfg.Context.BarStyle = "dots"
+		cfg.Context.BarStyle = barStyleDots
 		cfg.Context.BarEmpty = "O"
 		result, err := modules.ContextModule{}.Render(data, cfg)
 		require.NoError(t, err)
@@ -77,7 +79,7 @@ func TestResolveBarChars_ViaContextModule(t *testing.T) {
 
 	t.Run("explicit both override bar_style completely", func(t *testing.T) {
 		cfg := baseCfg
-		cfg.Context.BarStyle = "dots"
+		cfg.Context.BarStyle = barStyleDots
 		cfg.Context.BarFill = "#"
 		cfg.Context.BarEmpty = "-"
 		result, err := modules.ContextModule{}.Render(data, cfg)

--- a/internal/modules/helpers_test.go
+++ b/internal/modules/helpers_test.go
@@ -1,0 +1,69 @@
+package modules
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveBarChars(t *testing.T) {
+	t.Run("no style or explicit chars uses classic defaults", func(t *testing.T) {
+		fill, empty := resolveBarChars("", "", "")
+		assert.Equal(t, "\u2588", fill)
+		assert.Equal(t, "\u2591", empty)
+	})
+
+	t.Run("bar_style selects preset", func(t *testing.T) {
+		fill, empty := resolveBarChars("dots", "", "")
+		assert.Equal(t, "\u28ff", fill)
+		assert.Equal(t, "\u28c0", empty)
+	})
+
+	t.Run("bar_style blocks", func(t *testing.T) {
+		fill, empty := resolveBarChars("blocks", "", "")
+		assert.Equal(t, "\u2588", fill)
+		assert.Equal(t, "\u2592", empty)
+	})
+
+	t.Run("bar_style line", func(t *testing.T) {
+		fill, empty := resolveBarChars("line", "", "")
+		assert.Equal(t, "\u2501", fill)
+		assert.Equal(t, "\u2500", empty)
+	})
+
+	t.Run("bar_style squares", func(t *testing.T) {
+		fill, empty := resolveBarChars("squares", "", "")
+		assert.Equal(t, "\u25fc", fill)
+		assert.Equal(t, "\u25fb", empty)
+	})
+
+	t.Run("explicit bar_fill overrides bar_style", func(t *testing.T) {
+		fill, empty := resolveBarChars("dots", "X", "")
+		assert.Equal(t, "X", fill)
+		assert.Equal(t, "\u28c0", empty)
+	})
+
+	t.Run("explicit bar_empty overrides bar_style", func(t *testing.T) {
+		fill, empty := resolveBarChars("dots", "", "O")
+		assert.Equal(t, "\u28ff", fill)
+		assert.Equal(t, "O", empty)
+	})
+
+	t.Run("explicit both override bar_style completely", func(t *testing.T) {
+		fill, empty := resolveBarChars("dots", "X", "O")
+		assert.Equal(t, "X", fill)
+		assert.Equal(t, "O", empty)
+	})
+
+	t.Run("unknown bar_style falls back to classic", func(t *testing.T) {
+		fill, empty := resolveBarChars("unknown", "", "")
+		assert.Equal(t, "\u2588", fill)
+		assert.Equal(t, "\u2591", empty)
+	})
+
+	t.Run("explicit chars without bar_style", func(t *testing.T) {
+		fill, empty := resolveBarChars("", "#", "-")
+		assert.Equal(t, "#", fill)
+		assert.Equal(t, "-", empty)
+	})
+}

--- a/internal/modules/helpers_test.go
+++ b/internal/modules/helpers_test.go
@@ -1,69 +1,104 @@
-package modules
+package modules_test
 
 import (
 	"testing"
 
+	"github.com/felipeelias/claude-statusline/internal/config"
+	"github.com/felipeelias/claude-statusline/internal/input"
+	"github.com/felipeelias/claude-statusline/internal/modules"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestResolveBarChars(t *testing.T) {
-	t.Run("no style or explicit chars uses classic defaults", func(t *testing.T) {
-		fill, empty := resolveBarChars("", "", "")
-		assert.Equal(t, "\u2588", fill)
-		assert.Equal(t, "\u2591", empty)
+func TestResolveBarChars_ViaContextModule(t *testing.T) {
+	baseCfg := config.Default()
+	baseCfg.Context.Format = "{{.Bar}}"
+	baseCfg.Context.BarWidth = 5
+
+	data := input.Data{
+		ContextWindow: input.ContextWindow{UsedPercentage: 60.0},
+	}
+
+	t.Run("no bar_style uses classic defaults", func(t *testing.T) {
+		result, err := modules.ContextModule{}.Render(data, baseCfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "\u2588\u2588\u2588\u2591\u2591")
 	})
 
-	t.Run("bar_style selects preset", func(t *testing.T) {
-		fill, empty := resolveBarChars("dots", "", "")
-		assert.Equal(t, "\u28ff", fill)
-		assert.Equal(t, "\u28c0", empty)
+	t.Run("bar_style dots", func(t *testing.T) {
+		cfg := baseCfg
+		cfg.Context.BarStyle = "dots"
+		result, err := modules.ContextModule{}.Render(data, cfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "\u28ff\u28ff\u28ff\u28c0\u28c0")
 	})
 
 	t.Run("bar_style blocks", func(t *testing.T) {
-		fill, empty := resolveBarChars("blocks", "", "")
-		assert.Equal(t, "\u2588", fill)
-		assert.Equal(t, "\u2592", empty)
+		cfg := baseCfg
+		cfg.Context.BarStyle = "blocks"
+		result, err := modules.ContextModule{}.Render(data, cfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "\u2588\u2588\u2588\u2592\u2592")
 	})
 
 	t.Run("bar_style line", func(t *testing.T) {
-		fill, empty := resolveBarChars("line", "", "")
-		assert.Equal(t, "\u2501", fill)
-		assert.Equal(t, "\u2500", empty)
+		cfg := baseCfg
+		cfg.Context.BarStyle = "line"
+		result, err := modules.ContextModule{}.Render(data, cfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "\u2501\u2501\u2501\u2500\u2500")
 	})
 
 	t.Run("bar_style squares", func(t *testing.T) {
-		fill, empty := resolveBarChars("squares", "", "")
-		assert.Equal(t, "\u25fc", fill)
-		assert.Equal(t, "\u25fb", empty)
+		cfg := baseCfg
+		cfg.Context.BarStyle = "squares"
+		result, err := modules.ContextModule{}.Render(data, cfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "\u25fc\u25fc\u25fc\u25fb\u25fb")
 	})
 
 	t.Run("explicit bar_fill overrides bar_style", func(t *testing.T) {
-		fill, empty := resolveBarChars("dots", "X", "")
-		assert.Equal(t, "X", fill)
-		assert.Equal(t, "\u28c0", empty)
+		cfg := baseCfg
+		cfg.Context.BarStyle = "dots"
+		cfg.Context.BarFill = "#"
+		result, err := modules.ContextModule{}.Render(data, cfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "###\u28c0\u28c0")
 	})
 
 	t.Run("explicit bar_empty overrides bar_style", func(t *testing.T) {
-		fill, empty := resolveBarChars("dots", "", "O")
-		assert.Equal(t, "\u28ff", fill)
-		assert.Equal(t, "O", empty)
+		cfg := baseCfg
+		cfg.Context.BarStyle = "dots"
+		cfg.Context.BarEmpty = "O"
+		result, err := modules.ContextModule{}.Render(data, cfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "\u28ff\u28ff\u28ffOO")
 	})
 
 	t.Run("explicit both override bar_style completely", func(t *testing.T) {
-		fill, empty := resolveBarChars("dots", "X", "O")
-		assert.Equal(t, "X", fill)
-		assert.Equal(t, "O", empty)
+		cfg := baseCfg
+		cfg.Context.BarStyle = "dots"
+		cfg.Context.BarFill = "#"
+		cfg.Context.BarEmpty = "-"
+		result, err := modules.ContextModule{}.Render(data, cfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "###--")
 	})
 
 	t.Run("unknown bar_style falls back to classic", func(t *testing.T) {
-		fill, empty := resolveBarChars("unknown", "", "")
-		assert.Equal(t, "\u2588", fill)
-		assert.Equal(t, "\u2591", empty)
+		cfg := baseCfg
+		cfg.Context.BarStyle = "unknown"
+		result, err := modules.ContextModule{}.Render(data, cfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "\u2588\u2588\u2588\u2591\u2591")
 	})
 
 	t.Run("explicit chars without bar_style", func(t *testing.T) {
-		fill, empty := resolveBarChars("", "#", "-")
-		assert.Equal(t, "#", fill)
-		assert.Equal(t, "-", empty)
+		cfg := baseCfg
+		cfg.Context.BarFill = "#"
+		cfg.Context.BarEmpty = "-"
+		result, err := modules.ContextModule{}.Render(data, cfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "###--")
 	})
 }

--- a/internal/modules/usage.go
+++ b/internal/modules/usage.go
@@ -27,6 +27,8 @@ func (UsageModule) Render(data input.Data, cfg config.Config) (string, error) {
 	blockPct := rateLimits.FiveHour.UsedPercentage
 	weeklyPct := rateLimits.SevenDay.UsedPercentage
 
+	fill, empty := resolveBarChars(cfg.Usage.BarStyle, cfg.Usage.BarFill, cfg.Usage.BarEmpty)
+
 	templateData := struct {
 		BlockPct     float64
 		WeeklyPct    float64
@@ -37,8 +39,8 @@ func (UsageModule) Render(data input.Data, cfg config.Config) (string, error) {
 	}{
 		BlockPct:     blockPct,
 		WeeklyPct:    weeklyPct,
-		BlockBar:     buildBar(blockPct, cfg.Usage.BarWidth, cfg.Usage.BarFill, cfg.Usage.BarEmpty),
-		WeeklyBar:    buildBar(weeklyPct, cfg.Usage.BarWidth, cfg.Usage.BarFill, cfg.Usage.BarEmpty),
+		BlockBar:     buildBar(blockPct, cfg.Usage.BarWidth, fill, empty),
+		WeeklyBar:    buildBar(weeklyPct, cfg.Usage.BarWidth, fill, empty),
 		BlockResets:  formatResetTimestamp(rateLimits.FiveHour.ResetsAt),
 		WeeklyResets: formatResetTimestamp(rateLimits.SevenDay.ResetsAt),
 	}


### PR DESCRIPTION
## Summary

- Adds `bar_style` config field to context and usage modules with 5 named presets: `classic`, `blocks`, `dots`, `line`, `squares`
- Explicit `bar_fill`/`bar_empty` values override `bar_style` when both are set
- No bar_style set by default, so existing configs work without changes

## Why

Switching bar characters required knowing Unicode code points and setting two config fields. Named presets make it a one-liner: `bar_style = "dots"`.

## What

`bar_style` selects a preset pair of fill/empty characters. The resolution order: classic defaults -> bar_style preset -> explicit bar_fill/bar_empty. This gives users quick presets while preserving full override control.

| Name | Fill | Empty | Example (60%) |
|------|------|-------|---------------|
| `classic` | `█` | `░` | `███░░` |
| `blocks` | `█` | `▒` | `███▒▒` |
| `dots` | `⣿` | `⣀` | `⣿⣿⣿⣀⣀` |
| `line` | `━` | `─` | `━━━──` |
| `squares` | `◼` | `◻` | `◼◼◼◻◻` |

Config:

```toml
[context]
bar_style = "dots"

# explicit values still win
bar_fill = "#"  # overrides dots fill, keeps dots empty
```

Applied to both `[context]` and `[usage]` modules since they share bar rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable progress-bar styles with presets (classic, blocks, dots, line, squares).
  * Explicit bar character settings in context and usage now override preset styles when provided.

* **Documentation**
  * Roadmap updated to reflect the new bar-style configuration and precedence rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->