### PR TITLE
feat: add version module

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -127,39 +127,7 @@ style = "dim"
 
 ---
 
-### 6. Version module
-
-A new `version` module that displays the Claude Code version string from the JSON payload. The `version` field already exists in `input.Data`.
-
-**Config:**
-
-```toml
-[version]
-format = "v{{.Version}}"
-style = "dim"
-disabled = true
-```
-
-| Field      | Type   | Default           | Description                     |
-| ---------- | ------ | ----------------- | ------------------------------- |
-| `format`   | string | `"v{{.Version}}"` | Go template with `{{.Version}}` |
-| `style`    | string | `"dim"`           | ANSI style                      |
-| `disabled` | bool   | `true`            | Disabled by default             |
-
-**Template fields:**
-
-| Field          | Type   | Description                                 |
-| -------------- | ------ | ------------------------------------------- |
-| `{{.Version}}` | string | Claude Code version string (e.g., `1.0.33`) |
-
-**Behavior:**
-
-- If the version string is empty, renders empty.
-- Referenced as `$version` in the format string.
-
----
-
-### 7. Model name formatting options
+### 6. Model name formatting options
 
 The model module currently exposes `{{.DisplayName}}` from the JSON payload. Add `{{.ID}}` (the raw model ID) and a `{{.Short}}` field that extracts a compact name from the model ID.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,6 +118,7 @@ const (
 
 // Default returns a Config with hardcoded default values.
 //
+//nolint:funlen // single-struct initializer reads best as one block
 func Default() Config {
 	return Config{
 		Preset: "default",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -297,12 +297,13 @@ format = "$directory | $git_branch | $model | $cost | $context"
 # Template fields: Branch, InWorktree, IsDirty, IsClean,
 #   Staged, Modified, Untracked, Ahead, Behind, Conflicts
 
-# Disabled by default. Set disabled = false and add $module_name to format string to enable.
+# Disabled by default. Set disabled = false and add the module to format string to enable.
 
 # [version]
 # disabled = false
 # format = "v{{.Version}}"
 # style = "dim"
+
 # [session_timer]
 # disabled = false
 # format = "{{if .Hours}}{{.Hours}}h{{end}}{{printf \"%02d\" .Minutes}}m{{printf \"%02d\" .Seconds}}s"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	SessionTimer SessionTimerConfig `toml:"session_timer"`
 	LinesChanged LinesChangedConfig `toml:"lines_changed"`
 	Usage        UsageConfig        `toml:"usage"`
+	Version      VersionConfig      `toml:"version"`
 }
 
 // Threshold defines a conditional style based on a numeric value.
@@ -84,6 +85,13 @@ type LinesChangedConfig struct {
 	AddedStyle   string `toml:"added_style"`
 	RemovedStyle string `toml:"removed_style"`
 	Disabled     bool   `toml:"disabled"`
+}
+
+// VersionConfig holds version module settings.
+type VersionConfig struct {
+	Format   string `toml:"format"`
+	Style    string `toml:"style"`
+	Disabled bool   `toml:"disabled"`
 }
 
 // UsageConfig holds usage module settings.
@@ -159,6 +167,11 @@ func Default() Config {
 			AddedStyle:   "green",
 			RemovedStyle: "red",
 			Disabled:     true,
+		},
+		Version: VersionConfig{
+			Format:   `v{{.Version}}`,
+			Style:    "dim",
+			Disabled: true,
 		},
 		Usage: UsageConfig{
 			Format:   `{{.BlockBar}} {{printf "%.0f" .BlockPct}}% W:{{printf "%.0f" .WeeklyPct}}%`,
@@ -283,7 +296,12 @@ format = "$directory | $git_branch | $model | $cost | $context"
 # Template fields: Branch, InWorktree, IsDirty, IsClean,
 #   Staged, Modified, Untracked, Ahead, Behind, Conflicts
 
-# Disabled by default. Set disabled = false and add to format string to enable.
+# Disabled by default. Set disabled = false and add $module_name to format string to enable.
+
+# [version]
+# disabled = false
+# format = "v{{.Version}}"
+# style = "dim"
 # [session_timer]
 # disabled = false
 # format = "{{if .Hours}}{{.Hours}}h{{end}}{{printf \"%02d\" .Minutes}}m{{printf \"%02d\" .Seconds}}s"

--- a/internal/config/themes.go
+++ b/internal/config/themes.go
@@ -151,6 +151,9 @@ func powerlineConfig(preset string, format string, segFg string, colors [5]strin
 				{Above: usageHighThreshold, Style: segStyle(thresholds.high, colors[4])},
 			},
 		},
+		Version: VersionConfig{
+			Format: `v{{.Version}}`, Style: "dim", Disabled: true,
+		},
 	}
 }
 

--- a/internal/modules/version.go
+++ b/internal/modules/version.go
@@ -1,0 +1,26 @@
+package modules
+
+import (
+	"github.com/felipeelias/claude-statusline/internal/config"
+	"github.com/felipeelias/claude-statusline/internal/input"
+)
+
+// VersionModule renders the Claude Code version string.
+type VersionModule struct{}
+
+func (VersionModule) Name() string { return "version" }
+
+func (VersionModule) Render(data input.Data, cfg config.Config) (string, error) {
+	if data.Version == "" {
+		return "", nil
+	}
+
+	templateData := struct{ Version string }{Version: data.Version}
+
+	result, err := renderTemplate("version", cfg.Version.Format, templateData)
+	if err != nil {
+		return "", err
+	}
+
+	return wrapStyle(result, cfg.Version.Style), nil
+}

--- a/internal/modules/version_test.go
+++ b/internal/modules/version_test.go
@@ -1,0 +1,55 @@
+package modules_test
+
+import (
+	"testing"
+
+	"github.com/felipeelias/claude-statusline/internal/config"
+	"github.com/felipeelias/claude-statusline/internal/input"
+	"github.com/felipeelias/claude-statusline/internal/modules"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionModule_Name(t *testing.T) {
+	m := modules.VersionModule{}
+	assert.Equal(t, "version", m.Name())
+}
+
+func TestVersionModule_Render(t *testing.T) {
+	cfg := config.Default()
+
+	t.Run("renders version with default format", func(t *testing.T) {
+		data := input.Data{Version: "1.0.33"}
+
+		result, err := modules.VersionModule{}.Render(data, cfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "v1.0.33")
+	})
+
+	t.Run("empty version renders empty", func(t *testing.T) {
+		data := input.Data{Version: ""}
+
+		result, err := modules.VersionModule{}.Render(data, cfg)
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("applies style", func(t *testing.T) {
+		data := input.Data{Version: "2.1.80"}
+
+		result, err := modules.VersionModule{}.Render(data, cfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "\033[2m") // dim
+	})
+
+	t.Run("custom format", func(t *testing.T) {
+		customCfg := cfg
+		customCfg.Version.Format = "Claude {{.Version}}"
+
+		data := input.Data{Version: "1.0.33"}
+
+		result, err := modules.VersionModule{}.Render(data, customCfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "Claude 1.0.33")
+	})
+}

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -89,5 +89,6 @@ func buildRegistry(cfg config.Config) map[string]moduleEntry {
 		"session_timer": {module: modules.SessionTimerModule{}, disabled: cfg.SessionTimer.Disabled},
 		"lines_changed": {module: modules.LinesChangedModule{}, disabled: cfg.LinesChanged.Disabled},
 		"usage":         {module: modules.UsageModule{}, disabled: cfg.Usage.Disabled},
+		"version":       {module: modules.VersionModule{}, disabled: cfg.Version.Disabled},
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `version` module that displays the Claude Code version string
- Disabled by default, enabled via `disabled = false` and adding `$version` to the format string
- Renders empty when version is absent from the JSON payload

## Why

Users running different Claude Code versions across machines or sessions had no way to see the version at a glance.

## What

New module with `v{{.Version}}` default format and `dim` style. Uses the existing `version` field from the JSON payload. Config:

```toml
[version]
disabled = false
format = "v{{.Version}}"
style = "dim"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a version display module (disabled by default) with customizable format and styling; can be enabled in configuration.
* **Documentation**
  * Removed the previous "Version module" roadmap section; adjusted subsequent section numbering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->