### PR TITLE
chore: add pre-commit hooks for linter and tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,4 +10,4 @@ repos:
         entry: go test ./...
         language: system
         pass_filenames: false
-        types: [go]
+        always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v2.10.1
+    hooks:
+      - id: golangci-lint-full
+  - repo: local
+    hooks:
+      - id: go-test
+        name: go test
+        entry: go test ./...
+        language: system
+        pass_filenames: false
+        types: [go]


### PR DESCRIPTION
## Summary

- Adds project-level `.pre-commit-config.yaml` with `golangci-lint` and `go test` hooks
- Runs on every commit targeting Go files

## Why

Lint failures kept slipping through to CI. Catching them locally before push saves a round-trip.

## What

Two hooks: `golangci-lint-full` from the official repo (matches CI's v2.10.1), and a local `go test ./...` hook. Works alongside the existing global gitleaks hook.