### PR TITLE
feat: add model name formatting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ style = "fg:#11111b bg:#cba6f7 bold"
 |--------|---------|-------------|
 | `directory` | on | Current directory (tilde-collapsed, truncated) |
 | `git_branch` | on | Git branch with status indicators (dirty, ahead/behind, worktree) |
-| `model` | on | Model display name |
+| `model` | on | Model name (display name, short name, or raw ID) |
 | `cost` | on | Session cost in USD |
 | `context` | on | Context window usage with progress bar |
 | `session_timer` | off | Session elapsed time |
@@ -121,6 +121,22 @@ format = "$directory | $git_branch | $model | $cost | $context | $session_timer"
 
 [session_timer]
 disabled = false
+```
+
+### Model module
+
+Template fields:
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| `{{.DisplayName}}` | Display name from Claude Code (default) | `Claude Sonnet 4.6` |
+| `{{.Short}}` | Compact name extracted from model ID | `Sonnet 4.6` |
+| `{{.ID}}` | Raw model ID | `claude-sonnet-4-6-20250514` |
+
+```toml
+[model]
+format = "{{.Short}}"
+style = "bold"
 ```
 
 ### Usage module

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -265,6 +265,7 @@ format = "$directory | $git_branch | $model | $cost | $context"
 # [model]
 # format = "{{.DisplayName}}"
 # style = "bold"
+# Template fields: DisplayName, ID, Short (e.g. "Sonnet 4.6")
 
 # [directory]
 # format = "{{.Dir}}"

--- a/internal/modules/model.go
+++ b/internal/modules/model.go
@@ -30,7 +30,7 @@ func (ModelModule) Name() string { return "model" }
 
 func (ModelModule) Render(data input.Data, cfg config.Config) (string, error) {
 	displayName := data.Model.DisplayName
-	if displayName == "" {
+	if displayName == "" && data.Model.ID == "" {
 		return "", nil
 	}
 

--- a/internal/modules/model.go
+++ b/internal/modules/model.go
@@ -8,7 +8,7 @@ import (
 	"github.com/felipeelias/claude-statusline/internal/input"
 )
 
-var modelIDPattern = regexp.MustCompile(`claude-(opus|sonnet|haiku)-(\d+)-(\d+)`)
+var modelIDPattern = regexp.MustCompile(`^claude-(opus|sonnet|haiku)-(\d+)-(\d+)(?:-\d+)?$`)
 
 // ShortName extracts a compact name from a model ID (e.g. "Sonnet 4.6").
 // Falls back to displayName if the ID doesn't match the expected pattern.

--- a/internal/modules/model.go
+++ b/internal/modules/model.go
@@ -1,9 +1,27 @@
 package modules
 
 import (
+	"regexp"
+	"strings"
+
 	"github.com/felipeelias/claude-statusline/internal/config"
 	"github.com/felipeelias/claude-statusline/internal/input"
 )
+
+var modelIDPattern = regexp.MustCompile(`claude-(opus|sonnet|haiku)-(\d+)-(\d+)`)
+
+// ShortName extracts a compact name from a model ID (e.g. "Sonnet 4.6").
+// Falls back to displayName if the ID doesn't match the expected pattern.
+func ShortName(id, displayName string) string {
+	match := modelIDPattern.FindStringSubmatch(id)
+	if match == nil {
+		return displayName
+	}
+
+	family := strings.ToUpper(match[1][:1]) + match[1][1:]
+
+	return family + " " + match[2] + "." + match[3]
+}
 
 // ModelModule renders the AI model name.
 type ModelModule struct{}
@@ -16,7 +34,15 @@ func (ModelModule) Render(data input.Data, cfg config.Config) (string, error) {
 		return "", nil
 	}
 
-	templateData := struct{ DisplayName string }{DisplayName: displayName}
+	templateData := struct {
+		ID          string
+		DisplayName string
+		Short       string
+	}{
+		ID:          data.Model.ID,
+		DisplayName: displayName,
+		Short:       ShortName(data.Model.ID, displayName),
+	}
 
 	result, err := renderTemplate("model", cfg.Model.Format, templateData)
 	if err != nil {

--- a/internal/modules/model_test.go
+++ b/internal/modules/model_test.go
@@ -57,17 +57,30 @@ func TestModelModule_Render(t *testing.T) {
 		assert.Contains(t, result, "\033[0m")
 	})
 
-	t.Run("empty display name returns empty string", func(t *testing.T) {
+	t.Run("empty display name and ID returns empty string", func(t *testing.T) {
 		data := input.Data{
-			Model: input.Model{
-				ID:          "claude-opus-4",
-				DisplayName: "",
-			},
+			Model: input.Model{},
 		}
 
 		result, err := modules.ModelModule{}.Render(data, cfg)
 		require.NoError(t, err)
 		assert.Empty(t, result)
+	})
+
+	t.Run("empty display name with ID renders via ID format", func(t *testing.T) {
+		customCfg := config.Default()
+		customCfg.Model.Format = "{{.ID}}"
+
+		data := input.Data{
+			Model: input.Model{
+				ID:          "claude-sonnet-4-6-20250514",
+				DisplayName: "",
+			},
+		}
+
+		result, err := modules.ModelModule{}.Render(data, customCfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "claude-sonnet-4-6-20250514")
 	})
 
 	t.Run("custom format template", func(t *testing.T) {

--- a/internal/modules/model_test.go
+++ b/internal/modules/model_test.go
@@ -28,6 +28,8 @@ func TestShortName(t *testing.T) {
 		{"no date suffix", "claude-sonnet-4-6", "Claude Sonnet 4.6", "Sonnet 4.6"},
 		{"unknown model falls back", "gpt-4o", "GPT-4o", "GPT-4o"},
 		{"empty id falls back", "", "Some Model", "Some Model"},
+		{"prefix mismatch falls back", "xclaude-sonnet-4-6", "X", "X"},
+		{"suffix mismatch falls back", "claude-sonnet-4-6-foo", "X", "X"},
 	}
 
 	for _, tt := range tests {

--- a/internal/modules/model_test.go
+++ b/internal/modules/model_test.go
@@ -15,6 +15,28 @@ func TestModelModule_Name(t *testing.T) {
 	assert.Equal(t, "model", m.Name())
 }
 
+func TestShortName(t *testing.T) {
+	tests := []struct {
+		name        string
+		id          string
+		displayName string
+		want        string
+	}{
+		{"sonnet", "claude-sonnet-4-6-20250514", "Claude Sonnet 4.6", "Sonnet 4.6"},
+		{"opus", "claude-opus-4-6-20250514", "Claude Opus 4.6", "Opus 4.6"},
+		{"haiku", "claude-haiku-4-5-20251001", "Claude Haiku 4.5", "Haiku 4.5"},
+		{"no date suffix", "claude-sonnet-4-6", "Claude Sonnet 4.6", "Sonnet 4.6"},
+		{"unknown model falls back", "gpt-4o", "GPT-4o", "GPT-4o"},
+		{"empty id falls back", "", "Some Model", "Some Model"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, modules.ShortName(tt.id, tt.displayName))
+		})
+	}
+}
+
 func TestModelModule_Render(t *testing.T) {
 	cfg := config.Default()
 
@@ -57,5 +79,37 @@ func TestModelModule_Render(t *testing.T) {
 		result, err := modules.ModelModule{}.Render(data, customCfg)
 		require.NoError(t, err)
 		assert.Contains(t, result, "model: Sonnet")
+	})
+
+	t.Run("short name format", func(t *testing.T) {
+		customCfg := config.Default()
+		customCfg.Model.Format = "{{.Short}}"
+
+		data := input.Data{
+			Model: input.Model{
+				ID:          "claude-sonnet-4-6-20250514",
+				DisplayName: "Claude Sonnet 4.6",
+			},
+		}
+
+		result, err := modules.ModelModule{}.Render(data, customCfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "Sonnet 4.6")
+	})
+
+	t.Run("ID format", func(t *testing.T) {
+		customCfg := config.Default()
+		customCfg.Model.Format = "{{.ID}}"
+
+		data := input.Data{
+			Model: input.Model{
+				ID:          "claude-sonnet-4-6-20250514",
+				DisplayName: "Claude Sonnet 4.6",
+			},
+		}
+
+		result, err := modules.ModelModule{}.Render(data, customCfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "claude-sonnet-4-6-20250514")
 	})
 }


### PR DESCRIPTION
## Summary

- Add `{{.ID}}` and `{{.Short}}` template fields to the model module
- `{{.Short}}` extracts compact names from model IDs (e.g. `claude-sonnet-4-6-20250514` → `Sonnet 4.6`)
- Falls back to `{{.DisplayName}}` for unrecognized model IDs
- Default format unchanged (`{{.DisplayName}}`)

## Usage

```toml
[model]
format = "{{.Short}}"
```

## Test plan

- [x] `ShortName` tested for sonnet, opus, haiku, no date suffix, unknown fallback, empty ID
- [x] Render tests for `{{.Short}}` and `{{.ID}}` template formats
- [x] Full test suite passes
- [x] Linter clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Models now support a computed short name (e.g., "Sonnet 4.6") and expose it for display.
  * Template configuration now includes {{.Short}} and {{.ID}} as available variables for custom model formatting.

* **Documentation**
  * Updated configuration docs and examples to show available model display fields and formatting.

* **Tests**
  * Added tests validating short-name generation and template rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->