### PR TITLE
feat: add vim_mode module

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ style = "fg:#11111b bg:#cba6f7 bold"
 | `session_timer` | off | Session elapsed time |
 | `lines_changed` | off | Lines added/removed |
 | `usage` | off | Plan usage limits (5-hour block and weekly) |
+| `vim_mode` | off | Vim mode indicator (NORMAL, INSERT, etc.) |
 
 ### Enabling modules
 
@@ -170,6 +171,25 @@ format = '{{if ge .BlockPct 70.0}}{{.BlockBar}} {{printf "%.0f" .BlockPct}}%{{en
 ```
 
 The module renders empty if `rate_limits` is not present in the Claude Code payload (older versions).
+
+### Vim mode module
+
+The `vim_mode` module shows the current vim editor mode when vim mode is enabled in Claude Code.
+
+```toml
+format = "$vim_mode | $directory | $git_branch | $model | $cost | $context"
+
+[vim_mode]
+disabled = false
+```
+
+Template fields:
+
+| Field | Description |
+|-------|-------------|
+| `{{.Mode}}` | Current vim mode (e.g. `NORMAL`, `INSERT`) |
+
+The module renders empty if vim mode is not enabled or the mode string is empty.
 
 ## Style system
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	LinesChanged LinesChangedConfig `toml:"lines_changed"`
 	Usage        UsageConfig        `toml:"usage"`
 	Version      VersionConfig      `toml:"version"`
+	VimMode      VimModeConfig      `toml:"vim_mode"`
 }
 
 // Threshold defines a conditional style based on a numeric value.
@@ -106,6 +107,13 @@ type UsageConfig struct {
 	Thresholds []Threshold `toml:"thresholds"`
 }
 
+// VimModeConfig holds vim mode module settings.
+type VimModeConfig struct {
+	Format   string `toml:"format"`
+	Style    string `toml:"style"`
+	Disabled bool   `toml:"disabled"`
+}
+
 const (
 	defaultTruncationLength = 3
 	defaultBarWidth = 5
@@ -183,6 +191,11 @@ func Default() Config {
 				{Above: usageWarnThreshold, Style: "yellow"},
 				{Above: usageHighThreshold, Style: "red"},
 			},
+		},
+		VimMode: VimModeConfig{
+			Format:   "{{.Mode}}",
+			Style:    "bold yellow",
+			Disabled: true,
 		},
 	}
 }
@@ -331,6 +344,12 @@ format = "$directory | $git_branch | $model | $cost | $context"
 #   { above = 90, style = "red" },
 # ]
 # Template fields: BlockPct, WeeklyPct, BlockBar, WeeklyBar, BlockResets, WeeklyResets
+
+# [vim_mode]
+# disabled = false
+# format = "{{.Mode}}"
+# style = "bold yellow"
+# Template fields: Mode (e.g. "NORMAL", "INSERT")
 `
 
 // SampleConfig returns a commented TOML config template for the init command.

--- a/internal/config/themes.go
+++ b/internal/config/themes.go
@@ -154,6 +154,9 @@ func powerlineConfig(preset string, format string, segFg string, colors [5]strin
 		Version: VersionConfig{
 			Format: `v{{.Version}}`, Style: "dim", Disabled: true,
 		},
+		VimMode: VimModeConfig{
+			Format: "{{.Mode}}", Style: "bold yellow", Disabled: true,
+		},
 	}
 }
 

--- a/internal/modules/vimmode.go
+++ b/internal/modules/vimmode.go
@@ -1,0 +1,26 @@
+package modules
+
+import (
+	"github.com/felipeelias/claude-statusline/internal/config"
+	"github.com/felipeelias/claude-statusline/internal/input"
+)
+
+// VimModeModule renders the current vim editor mode.
+type VimModeModule struct{}
+
+func (VimModeModule) Name() string { return "vim_mode" }
+
+func (VimModeModule) Render(data input.Data, cfg config.Config) (string, error) {
+	if data.Vim == nil || data.Vim.Mode == "" {
+		return "", nil
+	}
+
+	templateData := struct{ Mode string }{Mode: data.Vim.Mode}
+
+	result, err := renderTemplate("vim_mode", cfg.VimMode.Format, templateData)
+	if err != nil {
+		return "", err
+	}
+
+	return wrapStyle(result, cfg.VimMode.Style), nil
+}

--- a/internal/modules/vimmode_test.go
+++ b/internal/modules/vimmode_test.go
@@ -1,0 +1,72 @@
+package modules_test
+
+import (
+	"testing"
+
+	"github.com/felipeelias/claude-statusline/internal/config"
+	"github.com/felipeelias/claude-statusline/internal/input"
+	"github.com/felipeelias/claude-statusline/internal/modules"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVimModeModule_Name(t *testing.T) {
+	m := modules.VimModeModule{}
+	assert.Equal(t, "vim_mode", m.Name())
+}
+
+func TestVimModeModule_Render(t *testing.T) {
+	cfg := config.Default()
+
+	t.Run("renders NORMAL mode", func(t *testing.T) {
+		data := input.Data{Vim: &input.Vim{Mode: "NORMAL"}}
+
+		result, err := modules.VimModeModule{}.Render(data, cfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "NORMAL")
+	})
+
+	t.Run("renders INSERT mode", func(t *testing.T) {
+		data := input.Data{Vim: &input.Vim{Mode: "INSERT"}}
+
+		result, err := modules.VimModeModule{}.Render(data, cfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "INSERT")
+	})
+
+	t.Run("nil vim renders empty", func(t *testing.T) {
+		data := input.Data{Vim: nil}
+
+		result, err := modules.VimModeModule{}.Render(data, cfg)
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("empty mode renders empty", func(t *testing.T) {
+		data := input.Data{Vim: &input.Vim{Mode: ""}}
+
+		result, err := modules.VimModeModule{}.Render(data, cfg)
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("applies style", func(t *testing.T) {
+		data := input.Data{Vim: &input.Vim{Mode: "NORMAL"}}
+
+		result, err := modules.VimModeModule{}.Render(data, cfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "\033[1;33m") // bold yellow
+		assert.Contains(t, result, "\033[0m")    // reset
+	})
+
+	t.Run("custom format", func(t *testing.T) {
+		customCfg := cfg
+		customCfg.VimMode.Format = "[{{.Mode}}]"
+
+		data := input.Data{Vim: &input.Vim{Mode: "NORMAL"}}
+
+		result, err := modules.VimModeModule{}.Render(data, customCfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "[NORMAL]")
+	})
+}

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -90,5 +90,6 @@ func buildRegistry(cfg config.Config) map[string]moduleEntry {
 		"lines_changed": {module: modules.LinesChangedModule{}, disabled: cfg.LinesChanged.Disabled},
 		"usage":         {module: modules.UsageModule{}, disabled: cfg.Usage.Disabled},
 		"version":       {module: modules.VersionModule{}, disabled: cfg.Version.Disabled},
+		"vim_mode":      {module: modules.VimModeModule{}, disabled: cfg.VimMode.Disabled},
 	}
 }


### PR DESCRIPTION
## Summary

- New `vim_mode` module that displays the current vim editor mode (NORMAL/INSERT) when vim mode is enabled in Claude Code
- Disabled by default; enable with `disabled = false` and add `$vim_mode` to format string
- Renders empty when vim mode is not active (graceful degradation)

## Changes

- `internal/modules/vimmode.go` — new module implementation
- `internal/modules/vimmode_test.go` — tests for render, empty states, custom format
- `internal/config/config.go` — `VimModeConfig` struct and defaults
- `internal/config/themes.go` — preset defaults
- `internal/render/render.go` — module registration
- `README.md` — documentation

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: enable vim mode in Claude Code, verify mode displays

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Vim mode indicator that displays your current Vim editor mode (e.g., NORMAL, INSERT) with customizable formatting and styling options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->