### PR TITLE
feat: add agent_name module

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ style = "fg:#11111b bg:#cba6f7 bold"
 | `lines_changed` | off | Lines added/removed |
 | `usage` | off | Plan usage limits (5-hour block and weekly) |
 | `vim_mode` | off | Vim mode indicator (NORMAL, INSERT, etc.) |
+| `agent_name` | off | Agent name when running with `--agent` |
 
 ### Enabling modules
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	Usage        UsageConfig        `toml:"usage"`
 	Version      VersionConfig      `toml:"version"`
 	VimMode      VimModeConfig      `toml:"vim_mode"`
+	AgentName    AgentNameConfig    `toml:"agent_name"`
 }
 
 // Threshold defines a conditional style based on a numeric value.
@@ -94,6 +95,13 @@ type LinesChangedConfig struct {
 
 // VersionConfig holds version module settings.
 type VersionConfig struct {
+	Format   string `toml:"format"`
+	Style    string `toml:"style"`
+	Disabled bool   `toml:"disabled"`
+}
+
+// AgentNameConfig holds agent name module settings.
+type AgentNameConfig struct {
 	Format   string `toml:"format"`
 	Style    string `toml:"style"`
 	Disabled bool   `toml:"disabled"`
@@ -200,6 +208,11 @@ func Default() Config {
 		VimMode: VimModeConfig{
 			Format:   "{{.Mode}}",
 			Style:    "bold yellow",
+			Disabled: true,
+		},
+		AgentName: AgentNameConfig{
+			Format:   "{{.Name}}",
+			Style:    "bold magenta",
 			Disabled: true,
 		},
 	}
@@ -337,6 +350,12 @@ format = "$directory | $git_branch | $model | $cost | $context"
 # format = "+{{.Added}} -{{.Removed}}"
 # added_style = "green"
 # removed_style = "red"
+
+# [agent_name]
+# disabled = false
+# format = "{{.Name}}"
+# style = "bold magenta"
+# Template fields: Name (e.g. "security-reviewer")
 
 # Requires Claude Code 2.1.80+ which provides rate_limits in the status line payload.
 # Add $usage to your format string to display it.

--- a/internal/config/themes.go
+++ b/internal/config/themes.go
@@ -160,6 +160,9 @@ func powerlineConfig(preset string, format string, segFg string, colors [5]strin
 		VimMode: VimModeConfig{
 			Format: "{{.Mode}}", Style: "bold yellow", Disabled: true,
 		},
+		AgentName: AgentNameConfig{
+			Format: "{{.Name}}", Style: "bold magenta", Disabled: true,
+		},
 	}
 }
 

--- a/internal/modules/agentname.go
+++ b/internal/modules/agentname.go
@@ -1,0 +1,26 @@
+package modules
+
+import (
+	"github.com/felipeelias/claude-statusline/internal/config"
+	"github.com/felipeelias/claude-statusline/internal/input"
+)
+
+// AgentNameModule renders the agent name when running with --agent.
+type AgentNameModule struct{}
+
+func (AgentNameModule) Name() string { return "agent_name" }
+
+func (AgentNameModule) Render(data input.Data, cfg config.Config) (string, error) {
+	if data.Agent == nil || data.Agent.Name == "" {
+		return "", nil
+	}
+
+	templateData := struct{ Name string }{Name: data.Agent.Name}
+
+	result, err := renderTemplate("agent_name", cfg.AgentName.Format, templateData)
+	if err != nil {
+		return "", err
+	}
+
+	return wrapStyle(result, cfg.AgentName.Style), nil
+}

--- a/internal/modules/agentname_test.go
+++ b/internal/modules/agentname_test.go
@@ -1,0 +1,64 @@
+package modules_test
+
+import (
+	"testing"
+
+	"github.com/felipeelias/claude-statusline/internal/config"
+	"github.com/felipeelias/claude-statusline/internal/input"
+	"github.com/felipeelias/claude-statusline/internal/modules"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentNameModule_Name(t *testing.T) {
+	m := modules.AgentNameModule{}
+	assert.Equal(t, "agent_name", m.Name())
+}
+
+func TestAgentNameModule_Render(t *testing.T) {
+	cfg := config.Default()
+
+	t.Run("renders agent name with default format", func(t *testing.T) {
+		data := input.Data{Agent: &input.Agent{Name: "security-reviewer"}}
+
+		result, err := modules.AgentNameModule{}.Render(data, cfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "security-reviewer")
+	})
+
+	t.Run("nil agent renders empty", func(t *testing.T) {
+		data := input.Data{Agent: nil}
+
+		result, err := modules.AgentNameModule{}.Render(data, cfg)
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("empty agent name renders empty", func(t *testing.T) {
+		data := input.Data{Agent: &input.Agent{Name: ""}}
+
+		result, err := modules.AgentNameModule{}.Render(data, cfg)
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("applies style", func(t *testing.T) {
+		data := input.Data{Agent: &input.Agent{Name: "code-reviewer"}}
+
+		result, err := modules.AgentNameModule{}.Render(data, cfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "\033[1;35m") // bold magenta
+		assert.Contains(t, result, "\033[0m")    // reset
+	})
+
+	t.Run("custom format", func(t *testing.T) {
+		customCfg := cfg
+		customCfg.AgentName.Format = "agent:{{.Name}}"
+
+		data := input.Data{Agent: &input.Agent{Name: "security-reviewer"}}
+
+		result, err := modules.AgentNameModule{}.Render(data, customCfg)
+		require.NoError(t, err)
+		assert.Contains(t, result, "agent:security-reviewer")
+	})
+}

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -91,5 +91,6 @@ func buildRegistry(cfg config.Config) map[string]moduleEntry {
 		"usage":         {module: modules.UsageModule{}, disabled: cfg.Usage.Disabled},
 		"version":       {module: modules.VersionModule{}, disabled: cfg.Version.Disabled},
 		"vim_mode":      {module: modules.VimModeModule{}, disabled: cfg.VimMode.Disabled},
+		"agent_name":    {module: modules.AgentNameModule{}, disabled: cfg.AgentName.Disabled},
 	}
 }


### PR DESCRIPTION
## Summary

- New `agent_name` module that displays the agent name when running Claude Code with `--agent` or agent settings
- Disabled by default; enable with `disabled = false` and add `$agent_name` to format string
- Renders empty when not running as an agent (graceful degradation)

## Changes

- `internal/modules/agentname.go` — new module implementation
- `internal/modules/agentname_test.go` — tests for render, empty states, custom format
- `internal/config/config.go` — `AgentNameConfig` struct and defaults
- `internal/config/themes.go` — preset defaults
- `internal/render/render.go` — module registration
- `README.md` — documentation

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: run with `--agent`, verify agent name displays

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `agent_name` module to display the agent name when running with `--agent` flag
  * Module is configurable with custom format templates and ANSI styling options
  * Disabled by default; can be enabled in configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->