### PR TITLE
feat: add OSC 8 clickable hyperlinks for git_branch and directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,31 @@ format = '{{if ge .BlockPct 70.0}}{{.BlockBar}} {{printf "%.0f" .BlockPct}}%{{en
 
 The module renders empty if `rate_limits` is not present in the Claude Code payload (older versions).
 
+## Clickable hyperlinks (OSC 8)
+
+Modules can wrap their output in [OSC 8 terminal hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda), making text clickable in supported terminals.
+
+### git_branch
+
+When enabled, the branch name links to the branch page on GitHub/GitLab/Bitbucket. The base URL is auto-detected from `git remote get-url origin`.
+
+```toml
+[git_branch]
+hyperlink = true
+# hyperlink_base_url = "https://github.com/owner/repo"  # override auto-detection
+```
+
+### directory
+
+When enabled, the directory text links to the path using a configurable URL template. The default opens `file://` URLs; set `hyperlink_url_template` for VS Code or other editors.
+
+```toml
+[directory]
+hyperlink = true
+# hyperlink_url_template = "file://{{.AbsPath}}"         # default
+# hyperlink_url_template = "vscode://file{{.AbsPath}}"   # open in VS Code
+```
+
 ## Style system
 
 Modules support a `style` field that accepts several formats:

--- a/README.md
+++ b/README.md
@@ -177,7 +177,13 @@ Modules can wrap their output in [OSC 8 terminal hyperlinks](https://gist.github
 
 ### git_branch
 
-When enabled, the branch name links to the branch page on GitHub/GitLab/Bitbucket. The base URL is auto-detected from `git remote get-url origin`.
+When enabled, the branch name becomes a clickable link to the branch page on the remote. The base URL is auto-detected from `git remote get-url origin`, and the branch path pattern is selected based on the host:
+
+- **GitHub** (default): `/tree/<branch>`
+- **GitLab** (hosts containing "gitlab"): `/-/tree/<branch>`
+- **Bitbucket** (hosts containing "bitbucket"): `/src/<branch>`
+
+Branch names are percent-encoded so characters like `#` don't break the URL.
 
 ```toml
 [git_branch]
@@ -187,12 +193,16 @@ hyperlink = true
 
 ### directory
 
-When enabled, the directory text links to the path using a configurable URL template. The default opens `file://` URLs; set `hyperlink_url_template` for VS Code or other editors.
+When enabled, the directory text links to the path using a configurable URL template. The default opens `file://` URLs with properly encoded paths; set `hyperlink_url_template` for VS Code or other editors.
+
+Template fields:
+- `{{.AbsPathEncoded}}` — percent-encoded absolute path (use for URLs)
+- `{{.AbsPath}}` — raw absolute path (use for schemes that handle raw paths, like `vscode://`)
 
 ```toml
 [directory]
 hyperlink = true
-# hyperlink_url_template = "file://{{.AbsPath}}"         # default
+# hyperlink_url_template = "file://{{.AbsPathEncoded}}"  # default
 # hyperlink_url_template = "vscode://file{{.AbsPath}}"   # open in VS Code
 ```
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,10 +38,12 @@ type ModelConfig struct {
 
 // DirectoryConfig holds directory module settings.
 type DirectoryConfig struct {
-	Format           string `toml:"format"`
-	Style            string `toml:"style"`
-	Disabled         bool   `toml:"disabled"`
-	TruncationLength int    `toml:"truncation_length"`
+	Format               string `toml:"format"`
+	Style                string `toml:"style"`
+	Disabled             bool   `toml:"disabled"`
+	TruncationLength     int    `toml:"truncation_length"`
+	Hyperlink            bool   `toml:"hyperlink"`
+	HyperlinkURLTemplate string `toml:"hyperlink_url_template"`
 }
 
 // CostConfig holds cost module settings.
@@ -66,10 +68,12 @@ type ContextConfig struct {
 
 // GitBranchConfig holds git branch module settings.
 type GitBranchConfig struct {
-	Format   string `toml:"format"`
-	Style    string `toml:"style"`
-	Disabled bool   `toml:"disabled"`
-	Mode     string `toml:"mode"` // "detailed" (default) or "simple"
+	Format           string `toml:"format"`
+	Style            string `toml:"style"`
+	Disabled         bool   `toml:"disabled"`
+	Mode             string `toml:"mode"` // "detailed" (default) or "simple"
+	Hyperlink        bool   `toml:"hyperlink"`
+	HyperlinkBaseURL string `toml:"hyperlink_base_url"`
 }
 
 // SessionTimerConfig holds session timer module settings.
@@ -128,9 +132,10 @@ func Default() Config {
 			Style:  "bold",
 		},
 		Directory: DirectoryConfig{
-			Format:           "{{.Dir}}",
-			Style:            "cyan",
-			TruncationLength: defaultTruncationLength,
+			Format:               "{{.Dir}}",
+			Style:                "cyan",
+			TruncationLength:     defaultTruncationLength,
+			HyperlinkURLTemplate: "file://{{.AbsPath}}",
 		},
 		Cost: CostConfig{
 			Format: `${{printf "%.2f" .TotalCostUSD}}`,
@@ -271,6 +276,8 @@ format = "$directory | $git_branch | $model | $cost | $context"
 # format = "{{.Dir}}"
 # style = "cyan"
 # truncation_length = 3
+# hyperlink = false
+# hyperlink_url_template = "file://{{.AbsPath}}"  # or "vscode://file{{.AbsPath}}"
 
 # [cost]
 # format = '${{printf "%.2f" .TotalCostUSD}}'
@@ -295,6 +302,8 @@ format = "$directory | $git_branch | $model | $cost | $context"
 # [git_branch]
 # mode = "detailed"  # "detailed" (default) or "simple" (fast, branch only)
 # style = "cyan"
+# hyperlink = false
+# hyperlink_base_url = ""  # auto-detected from git remote; set to override
 # Template fields: Branch, InWorktree, IsDirty, IsClean,
 #   Staged, Modified, Untracked, Ahead, Behind, Conflicts
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -135,7 +135,7 @@ func Default() Config {
 			Format:               "{{.Dir}}",
 			Style:                "cyan",
 			TruncationLength:     defaultTruncationLength,
-			HyperlinkURLTemplate: "file://{{.AbsPath}}",
+			HyperlinkURLTemplate: "file://{{.AbsPathEncoded}}",
 		},
 		Cost: CostConfig{
 			Format: `${{printf "%.2f" .TotalCostUSD}}`,
@@ -277,7 +277,7 @@ format = "$directory | $git_branch | $model | $cost | $context"
 # style = "cyan"
 # truncation_length = 3
 # hyperlink = false
-# hyperlink_url_template = "file://{{.AbsPath}}"  # or "vscode://file{{.AbsPath}}"
+# hyperlink_url_template = "file://{{.AbsPathEncoded}}"  # or "vscode://file{{.AbsPath}}"
 
 # [cost]
 # format = '${{printf "%.2f" .TotalCostUSD}}'

--- a/internal/config/themes.go
+++ b/internal/config/themes.go
@@ -103,7 +103,8 @@ func powerlineConfig(preset string, format string, segFg string, colors [5]strin
 		Format: format,
 		Directory: DirectoryConfig{
 			Format: " {{.Dir}} ", Style: segStyle(segFg, colors[0]),
-			TruncationLength: defaultTruncationLength,
+			TruncationLength:     defaultTruncationLength,
+			HyperlinkURLTemplate: "file://{{.AbsPathEncoded}}",
 		},
 		GitBranch: GitBranchConfig{
 			Format: " " + iconBranch + " {{.Branch}}" +

--- a/internal/modules/directory.go
+++ b/internal/modules/directory.go
@@ -1,8 +1,10 @@
 package modules
 
 import (
+	"bytes"
 	"os"
 	"strings"
+	"text/template"
 
 	"github.com/felipeelias/claude-statusline/internal/config"
 	"github.com/felipeelias/claude-statusline/internal/input"
@@ -57,6 +59,11 @@ func (m DirectoryModule) Render(data input.Data, cfg config.Config) (string, err
 		return "", err
 	}
 
+	if cfg.Directory.Hyperlink {
+		linkURL := resolveDirectoryHyperlink(cfg.Directory.HyperlinkURLTemplate, cwd)
+		result = WrapHyperlink(linkURL, result)
+	}
+
 	return wrapStyle(result, cfg.Directory.Style), nil
 }
 
@@ -103,4 +110,27 @@ func splitPathPrefix(path string) (string, string) {
 	}
 
 	return "", path
+}
+
+// resolveDirectoryHyperlink executes the URL template with the absolute path.
+// Returns empty string if the template is empty or fails to execute.
+func resolveDirectoryHyperlink(urlTemplate, absPath string) string {
+	if urlTemplate == "" {
+		return ""
+	}
+
+	tmpl, err := template.New("hyperlink_url").Parse(urlTemplate)
+	if err != nil {
+		return ""
+	}
+
+	data := struct{ AbsPath string }{AbsPath: absPath}
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, data)
+	if err != nil {
+		return ""
+	}
+
+	return buf.String()
 }

--- a/internal/modules/directory.go
+++ b/internal/modules/directory.go
@@ -2,6 +2,7 @@ package modules
 
 import (
 	"bytes"
+	"net/url"
 	"os"
 	"strings"
 	"text/template"
@@ -124,7 +125,13 @@ func resolveDirectoryHyperlink(urlTemplate, absPath string) string {
 		return ""
 	}
 
-	data := struct{ AbsPath string }{AbsPath: absPath}
+	data := struct {
+		AbsPath        string
+		AbsPathEncoded string
+	}{
+		AbsPath:        absPath,
+		AbsPathEncoded: (&url.URL{Path: absPath}).EscapedPath(),
+	}
 
 	var buf bytes.Buffer
 	err = tmpl.Execute(&buf, data)

--- a/internal/modules/gitbranch.go
+++ b/internal/modules/gitbranch.go
@@ -52,7 +52,30 @@ func (GitBranchModule) Render(data input.Data, cfg config.Config) (string, error
 		return "", err
 	}
 
+	result = gitBranchHyperlink(result, templateData.Branch, data.Cwd, cfg.GitBranch)
+
 	return wrapStyle(result, cfg.GitBranch.Style), nil
+}
+
+// gitBranchHyperlink wraps text in an OSC 8 hyperlink to the branch on the remote.
+// Returns text unchanged if hyperlink is disabled or no base URL can be determined.
+func gitBranchHyperlink(text, branch, cwd string, cfg config.GitBranchConfig) string {
+	if !cfg.Hyperlink {
+		return text
+	}
+
+	baseURL := cfg.HyperlinkBaseURL
+	if baseURL == "" {
+		baseURL = GitRemoteToHTTPS(gitRemoteURL(cwd))
+	}
+
+	if baseURL == "" {
+		return text
+	}
+
+	linkURL := strings.TrimSuffix(baseURL, "/") + "/tree/" + branch
+
+	return WrapHyperlink(linkURL, text)
 }
 
 type gitBranchTemplateData struct {

--- a/internal/modules/gitbranch.go
+++ b/internal/modules/gitbranch.go
@@ -73,9 +73,7 @@ func gitBranchHyperlink(text, branch, cwd string, cfg config.GitBranchConfig) st
 		return text
 	}
 
-	linkURL := strings.TrimSuffix(baseURL, "/") + "/tree/" + branch
-
-	return WrapHyperlink(linkURL, text)
+	return WrapHyperlink(BranchURL(baseURL, branch), text)
 }
 
 type gitBranchTemplateData struct {

--- a/internal/modules/hyperlink.go
+++ b/internal/modules/hyperlink.go
@@ -1,0 +1,58 @@
+package modules
+
+import (
+	"net/url"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// WrapHyperlink wraps text in an OSC 8 terminal hyperlink sequence.
+// If linkURL is empty, the text is returned unmodified.
+func WrapHyperlink(linkURL, text string) string {
+	if linkURL == "" {
+		return text
+	}
+
+	return "\033]8;;" + linkURL + "\033\\" + text + "\033]8;;\033\\"
+}
+
+// sshURLPattern matches SSH-style git remote URLs like git@github.com:owner/repo.git.
+var sshURLPattern = regexp.MustCompile(`^[\w.-]+@([\w.-]+):([\w./-]+?)(?:\.git)?$`)
+
+// GitRemoteToHTTPS converts a git remote URL (SSH or HTTPS) to an HTTPS base URL.
+// Returns empty string if the URL cannot be parsed.
+func GitRemoteToHTTPS(remoteURL string) string {
+	remoteURL = strings.TrimSpace(remoteURL)
+	if remoteURL == "" {
+		return ""
+	}
+
+	// Handle SSH URLs: git@github.com:owner/repo.git
+	if m := sshURLPattern.FindStringSubmatch(remoteURL); m != nil {
+		return "https://" + m[1] + "/" + m[2]
+	}
+
+	// Handle HTTPS URLs: https://github.com/owner/repo.git
+	parsed, err := url.Parse(remoteURL)
+	if err != nil || parsed.Host == "" {
+		return ""
+	}
+
+	path := strings.TrimSuffix(parsed.Path, ".git")
+
+	return "https://" + parsed.Host + path
+}
+
+// gitRemoteURL runs git remote get-url origin in the given directory.
+// Returns empty string if the command fails or git is not available.
+func gitRemoteURL(cwd string) string {
+	//nolint:noctx // no context available in module interface
+	cmd := exec.Command("git", "-C", cwd, "remote", "get-url", "origin")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+
+	return strings.TrimSpace(string(out))
+}

--- a/internal/modules/hyperlink.go
+++ b/internal/modules/hyperlink.go
@@ -18,7 +18,8 @@ func WrapHyperlink(linkURL, text string) string {
 }
 
 // sshURLPattern matches SSH-style git remote URLs like git@github.com:owner/repo.git.
-var sshURLPattern = regexp.MustCompile(`^[\w.-]+@([\w.-]+):([\w./-]+?)(?:\.git)?$`)
+// Uses permissive classes for user/host to handle hyphens in self-hosted hostnames.
+var sshURLPattern = regexp.MustCompile(`^[^@]+@([^:]+):([\w./-]+?)(?:\.git)?$`)
 
 // GitRemoteToHTTPS converts a git remote URL (SSH or HTTPS) to an HTTPS base URL.
 // Returns empty string if the URL cannot be parsed.
@@ -42,6 +43,40 @@ func GitRemoteToHTTPS(remoteURL string) string {
 	path := strings.TrimSuffix(parsed.Path, ".git")
 
 	return "https://" + parsed.Host + path
+}
+
+// BranchURL constructs a full branch URL from a base repo URL and branch name.
+// It detects the provider (GitHub, GitLab, Bitbucket) from the host and uses the
+// appropriate path pattern. Branch path segments are percent-encoded.
+func BranchURL(baseURL, branch string) string {
+	base := strings.TrimSuffix(baseURL, "/")
+	encoded := encodeBranchPath(branch)
+
+	parsed, err := url.Parse(baseURL)
+	if err != nil || parsed.Host == "" {
+		return base + "/tree/" + encoded
+	}
+
+	host := strings.ToLower(parsed.Hostname())
+
+	switch {
+	case strings.Contains(host, "gitlab"):
+		return base + "/-/tree/" + encoded
+	case strings.Contains(host, "bitbucket"):
+		return base + "/src/" + encoded
+	default:
+		return base + "/tree/" + encoded
+	}
+}
+
+// encodeBranchPath percent-encodes each segment of a branch name while preserving slashes.
+func encodeBranchPath(branch string) string {
+	segments := strings.Split(branch, "/")
+	for i, seg := range segments {
+		segments[i] = url.PathEscape(seg)
+	}
+
+	return strings.Join(segments, "/")
 }
 
 // gitRemoteURL runs git remote get-url origin in the given directory.

--- a/internal/modules/hyperlink_test.go
+++ b/internal/modules/hyperlink_test.go
@@ -81,11 +81,86 @@ func TestGitRemoteToHTTPS(t *testing.T) {
 			input:    "not-a-url",
 			expected: "",
 		},
+		{
+			name:     "SSH with hyphenated hostname",
+			input:    "git@my-gitlab.company.com:org/repo.git",
+			expected: "https://my-gitlab.company.com/org/repo",
+		},
+		{
+			name:     "SSH with hyphenated username",
+			input:    "my-user@github.com:owner/repo.git",
+			expected: "https://github.com/owner/repo",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			result := modules.GitRemoteToHTTPS(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestBranchURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseURL  string
+		branch   string
+		expected string
+	}{
+		{
+			name:     "GitHub default",
+			baseURL:  "https://github.com/owner/repo",
+			branch:   "main",
+			expected: "https://github.com/owner/repo/tree/main",
+		},
+		{
+			name:     "GitHub trailing slash",
+			baseURL:  "https://github.com/owner/repo/",
+			branch:   "main",
+			expected: "https://github.com/owner/repo/tree/main",
+		},
+		{
+			name:     "GitLab uses /-/tree/",
+			baseURL:  "https://gitlab.com/group/project",
+			branch:   "main",
+			expected: "https://gitlab.com/group/project/-/tree/main",
+		},
+		{
+			name:     "self-hosted GitLab",
+			baseURL:  "https://my-gitlab.company.com/org/repo",
+			branch:   "develop",
+			expected: "https://my-gitlab.company.com/org/repo/-/tree/develop",
+		},
+		{
+			name:     "Bitbucket uses /src/",
+			baseURL:  "https://bitbucket.org/team/repo",
+			branch:   "main",
+			expected: "https://bitbucket.org/team/repo/src/main",
+		},
+		{
+			name:     "branch with hash is encoded",
+			baseURL:  "https://github.com/owner/repo",
+			branch:   "fix/#123",
+			expected: "https://github.com/owner/repo/tree/fix/%23123",
+		},
+		{
+			name:     "branch with spaces is encoded",
+			baseURL:  "https://github.com/owner/repo",
+			branch:   "feature/my branch",
+			expected: "https://github.com/owner/repo/tree/feature/my%20branch",
+		},
+		{
+			name:     "simple branch with slash",
+			baseURL:  "https://github.com/owner/repo",
+			branch:   "feature/my-branch",
+			expected: "https://github.com/owner/repo/tree/feature/my-branch",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := modules.BranchURL(tc.baseURL, tc.branch)
 			assert.Equal(t, tc.expected, result)
 		})
 	}
@@ -176,7 +251,6 @@ func TestGitBranchModule_HyperlinkNoRemoteGraceful(t *testing.T) {
 func TestDirectoryModule_HyperlinkEnabled(t *testing.T) {
 	cfg := config.Default()
 	cfg.Directory.Hyperlink = true
-	cfg.Directory.HyperlinkURLTemplate = "file://{{.AbsPath}}"
 	cfg.Directory.Style = ""
 
 	data := input.Data{Cwd: "/home/user/projects/myapp"}
@@ -185,6 +259,18 @@ func TestDirectoryModule_HyperlinkEnabled(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, result, "\033]8;;file:///home/user/projects/myapp\033\\")
 	assert.Contains(t, result, "\033]8;;\033\\")
+}
+
+func TestDirectoryModule_HyperlinkEncodesSpaces(t *testing.T) {
+	cfg := config.Default()
+	cfg.Directory.Hyperlink = true
+	cfg.Directory.Style = ""
+
+	data := input.Data{Cwd: "/home/user/my projects/app"}
+
+	result, err := modules.NewDirectoryModuleWithHome("/home/user").Render(data, cfg)
+	require.NoError(t, err)
+	assert.Contains(t, result, "\033]8;;file:///home/user/my%20projects/app\033\\")
 }
 
 func TestDirectoryModule_HyperlinkDisabled(t *testing.T) {
@@ -210,6 +296,20 @@ func TestDirectoryModule_HyperlinkCustomTemplate(t *testing.T) {
 	result, err := modules.NewDirectoryModuleWithHome("/home/user").Render(data, cfg)
 	require.NoError(t, err)
 	assert.Contains(t, result, "\033]8;;vscode://file/home/user/projects/myapp\033\\")
+}
+
+func TestDirectoryModule_HyperlinkRawPathTemplate(t *testing.T) {
+	cfg := config.Default()
+	cfg.Directory.Hyperlink = true
+	cfg.Directory.HyperlinkURLTemplate = "vscode://file{{.AbsPath}}"
+	cfg.Directory.Style = ""
+
+	data := input.Data{Cwd: "/home/user/my projects/app"}
+
+	result, err := modules.NewDirectoryModuleWithHome("/home/user").Render(data, cfg)
+	require.NoError(t, err)
+	// AbsPath is raw — spaces are NOT encoded
+	assert.Contains(t, result, "\033]8;;vscode://file/home/user/my projects/app\033\\")
 }
 
 func TestDirectoryModule_HyperlinkEmptyTemplate(t *testing.T) {

--- a/internal/modules/hyperlink_test.go
+++ b/internal/modules/hyperlink_test.go
@@ -1,0 +1,227 @@
+package modules_test
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/felipeelias/claude-statusline/internal/config"
+	"github.com/felipeelias/claude-statusline/internal/input"
+	"github.com/felipeelias/claude-statusline/internal/modules"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrapHyperlink(t *testing.T) {
+	t.Run("wraps text with OSC 8 sequence", func(t *testing.T) {
+		result := modules.WrapHyperlink("https://github.com/owner/repo", "main")
+		expected := "\033]8;;https://github.com/owner/repo\033\\main\033]8;;\033\\"
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("empty URL returns text unchanged", func(t *testing.T) {
+		result := modules.WrapHyperlink("", "main")
+		assert.Equal(t, "main", result)
+	})
+}
+
+func TestGitRemoteToHTTPS(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "GitHub SSH with .git",
+			input:    "git@github.com:owner/repo.git",
+			expected: "https://github.com/owner/repo",
+		},
+		{
+			name:     "GitHub SSH without .git",
+			input:    "git@github.com:owner/repo",
+			expected: "https://github.com/owner/repo",
+		},
+		{
+			name:     "GitLab SSH",
+			input:    "git@gitlab.com:group/project.git",
+			expected: "https://gitlab.com/group/project",
+		},
+		{
+			name:     "Bitbucket SSH",
+			input:    "git@bitbucket.org:team/repo.git",
+			expected: "https://bitbucket.org/team/repo",
+		},
+		{
+			name:     "GitHub HTTPS with .git",
+			input:    "https://github.com/owner/repo.git",
+			expected: "https://github.com/owner/repo",
+		},
+		{
+			name:     "GitHub HTTPS without .git",
+			input:    "https://github.com/owner/repo",
+			expected: "https://github.com/owner/repo",
+		},
+		{
+			name:     "GitLab nested subgroup SSH",
+			input:    "git@gitlab.com:group/subgroup/project.git",
+			expected: "https://gitlab.com/group/subgroup/project",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "whitespace only",
+			input:    "  \n",
+			expected: "",
+		},
+		{
+			name:     "invalid URL",
+			input:    "not-a-url",
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := modules.GitRemoteToHTTPS(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+const branchOnlyFmt = "{{.Branch}}"
+
+func TestGitBranchModule_HyperlinkEnabled(t *testing.T) {
+	cfg := config.Default()
+	cfg.GitBranch.Hyperlink = true
+	cfg.GitBranch.HyperlinkBaseURL = "https://github.com/owner/repo"
+	// Use a simple format to make assertions easier.
+	cfg.GitBranch.Format = branchOnlyFmt
+	cfg.GitBranch.Style = ""
+
+	dir := initGitRepo(t)
+
+	cmd := exec.CommandContext(t.Context(), "git", "-C", dir, "checkout", "-b", "my-feature")
+	require.NoError(t, cmd.Run())
+
+	data := input.Data{Cwd: dir}
+	result, err := modules.GitBranchModule{}.Render(data, cfg)
+	require.NoError(t, err)
+	assert.Contains(t, result, "\033]8;;https://github.com/owner/repo/tree/my-feature\033\\")
+	assert.Contains(t, result, "my-feature")
+	assert.Contains(t, result, "\033]8;;\033\\")
+}
+
+func TestGitBranchModule_HyperlinkDisabled(t *testing.T) {
+	cfg := config.Default()
+	cfg.GitBranch.Hyperlink = false
+	cfg.GitBranch.Format = branchOnlyFmt
+	cfg.GitBranch.Style = ""
+
+	dir := initGitRepo(t)
+
+	data := input.Data{Cwd: dir}
+	result, err := modules.GitBranchModule{}.Render(data, cfg)
+	require.NoError(t, err)
+	assert.NotContains(t, result, "\033]8;;")
+}
+
+func TestGitBranchModule_HyperlinkAutoDetect(t *testing.T) {
+	origin := initGitRepo(t)
+
+	dir := t.TempDir()
+	cmd := exec.CommandContext(t.Context(), "git", "clone", origin, dir)
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null")
+	require.NoError(t, cmd.Run())
+
+	cmd = exec.CommandContext(t.Context(), "git", "-C", dir, "config", "user.email", "test@test.com")
+	require.NoError(t, cmd.Run())
+	cmd = exec.CommandContext(t.Context(), "git", "-C", dir, "config", "user.name", "Test")
+	require.NoError(t, cmd.Run())
+
+	cfg := config.Default()
+	cfg.GitBranch.Hyperlink = true
+	// No HyperlinkBaseURL set — auto-detect from remote.
+	cfg.GitBranch.Format = branchOnlyFmt
+	cfg.GitBranch.Style = ""
+
+	data := input.Data{Cwd: dir}
+	result, err := modules.GitBranchModule{}.Render(data, cfg)
+	require.NoError(t, err)
+	// The remote is a local path, so gitRemoteToHTTPS will return "" and no link is added.
+	// This tests graceful degradation.
+	assert.NotContains(t, result, "\033]8;;")
+	assert.NotEmpty(t, result) // branch name is present
+}
+
+func TestGitBranchModule_HyperlinkNoRemoteGraceful(t *testing.T) {
+	cfg := config.Default()
+	cfg.GitBranch.Hyperlink = true
+	// No base URL, and the repo has no remote.
+	cfg.GitBranch.Format = branchOnlyFmt
+	cfg.GitBranch.Style = ""
+
+	dir := initGitRepo(t)
+
+	data := input.Data{Cwd: dir}
+	result, err := modules.GitBranchModule{}.Render(data, cfg)
+	require.NoError(t, err)
+	// No remote available, no base URL — should render without hyperlink.
+	assert.NotContains(t, result, "\033]8;;")
+	assert.NotEmpty(t, result) // branch name is present
+}
+
+func TestDirectoryModule_HyperlinkEnabled(t *testing.T) {
+	cfg := config.Default()
+	cfg.Directory.Hyperlink = true
+	cfg.Directory.HyperlinkURLTemplate = "file://{{.AbsPath}}"
+	cfg.Directory.Style = ""
+
+	data := input.Data{Cwd: "/home/user/projects/myapp"}
+
+	result, err := modules.NewDirectoryModuleWithHome("/home/user").Render(data, cfg)
+	require.NoError(t, err)
+	assert.Contains(t, result, "\033]8;;file:///home/user/projects/myapp\033\\")
+	assert.Contains(t, result, "\033]8;;\033\\")
+}
+
+func TestDirectoryModule_HyperlinkDisabled(t *testing.T) {
+	cfg := config.Default()
+	cfg.Directory.Hyperlink = false
+	cfg.Directory.Style = ""
+
+	data := input.Data{Cwd: "/home/user/projects"}
+
+	result, err := modules.NewDirectoryModuleWithHome("/home/user").Render(data, cfg)
+	require.NoError(t, err)
+	assert.NotContains(t, result, "\033]8;;")
+}
+
+func TestDirectoryModule_HyperlinkCustomTemplate(t *testing.T) {
+	cfg := config.Default()
+	cfg.Directory.Hyperlink = true
+	cfg.Directory.HyperlinkURLTemplate = "vscode://file{{.AbsPath}}"
+	cfg.Directory.Style = ""
+
+	data := input.Data{Cwd: "/home/user/projects/myapp"}
+
+	result, err := modules.NewDirectoryModuleWithHome("/home/user").Render(data, cfg)
+	require.NoError(t, err)
+	assert.Contains(t, result, "\033]8;;vscode://file/home/user/projects/myapp\033\\")
+}
+
+func TestDirectoryModule_HyperlinkEmptyTemplate(t *testing.T) {
+	cfg := config.Default()
+	cfg.Directory.Hyperlink = true
+	cfg.Directory.HyperlinkURLTemplate = ""
+	cfg.Directory.Style = ""
+
+	data := input.Data{Cwd: "/home/user/projects"}
+
+	result, err := modules.NewDirectoryModuleWithHome("/home/user").Render(data, cfg)
+	require.NoError(t, err)
+	// Empty template means no hyperlink.
+	assert.NotContains(t, result, "\033]8;;")
+}


### PR DESCRIPTION
## Summary

- Add opt-in OSC 8 terminal hyperlinks to `git_branch` and `directory` modules
- **git_branch**: links to GitHub/GitLab/Bitbucket branch page, auto-detects remote URL (SSH→HTTPS conversion), supports manual override via `hyperlink_base_url`
- **directory**: links to file path (default `file://` protocol), customizable via `hyperlink_url_template` (e.g., `vscode://file{{.AbsPath}}`)
- Both default to `hyperlink = false` (opt-in); terminals without OSC 8 support show plain text

## Changes

- `internal/modules/hyperlink.go` — OSC 8 wrapper, SSH→HTTPS conversion, remote URL detection
- `internal/modules/hyperlink_test.go` — 12 test cases covering all paths
- `internal/modules/gitbranch.go` — hyperlink integration
- `internal/modules/directory.go` — hyperlink integration
- `internal/config/config.go` — new config fields and sample config
- `README.md` — documentation

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: enable hyperlinks, verify clickable links in supported terminal
- [x] Manual: verify graceful degradation when no remote URL available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clickable terminal hyperlinks for directories and git branches with provider-aware branch URLs and percent-encoding; directory links support configurable URL templates (file://, vscode://, etc.).

* **Documentation**
  * Added guidance and examples for enabling hyperlinks, template usage, and base-URL configuration.

* **Tests**
  * Added tests covering hyperlink generation, remote-to-HTTPS detection, templating, provider URL patterns, and graceful fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->